### PR TITLE
remove setobject and improve example

### DIFF
--- a/examples/component-architecture-basics/resources/deployment_resource.go
+++ b/examples/component-architecture-basics/resources/deployment_resource.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcehawk/operator-component-framework/pkg/feature"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -51,26 +52,28 @@ func (r *DeploymentResource) Object() (client.Object, error) {
 	return r.deployment, nil
 }
 
-// SetObject sets the underlying Kubernetes object, typically called by the framework after fetching.
-func (r *DeploymentResource) SetObject(obj client.Object) error {
-	if d, ok := obj.(*appsv1.Deployment); ok {
-		r.deployment = d
-		return nil
-	}
-	return fmt.Errorf("expected *appsv1.Deployment, got %T", obj)
-}
-
 // SetImmutable applies configuration that should not change after creation (e.g., selectors).
 // It's part of the Resource interface's two-step configuration model.
 func (r *DeploymentResource) SetImmutable() error {
-	// Baseline configuration that never changes
-	if r.deployment.Labels == nil {
-		r.deployment.Labels = make(map[string]string)
+	// Label selectors are immutable for Deployments once created.
+	// We set them here to ensure they are consistently applied at creation.
+	selectorLabels := map[string]string{
+		"app.kubernetes.io/instance": r.deployment.Name,
 	}
-	r.deployment.Labels["app.kubernetes.io/name"] = r.deployment.Name
-	r.deployment.Labels["managed-by"] = "example-operator"
 
-	// Example: set selectors or other create-once fields here.
+	if r.deployment.Spec.Selector == nil {
+		r.deployment.Spec.Selector = &metav1.LabelSelector{}
+	}
+	r.deployment.Spec.Selector.MatchLabels = selectorLabels
+
+	// Pod template labels MUST match the selector labels.
+	if r.deployment.Spec.Template.Labels == nil {
+		r.deployment.Spec.Template.Labels = make(map[string]string)
+	}
+	for k, v := range selectorLabels {
+		r.deployment.Spec.Template.Labels[k] = v
+	}
+
 	return nil
 }
 

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -99,7 +98,6 @@ var _ = Describe("Component Reconciler", func() {
 			res := &MockResource{}
 			res.On("Object").Return(cm, nil)
 			res.On("Identity").Return("ConfigMap/test-cm")
-			res.On("SetObject", mock.Anything).Return(nil)
 			res.On("SetImmutable").Return(nil)
 			res.On("SetMutable").Return(nil)
 
@@ -134,7 +132,6 @@ var _ = Describe("Component Reconciler", func() {
 			res := &MockAliveResource{}
 			res.On("Object").Return(cm, nil)
 			res.On("Identity").Return("ConfigMap/test-alive-cm")
-			res.On("SetObject", mock.Anything).Return(nil)
 			res.On("SetImmutable").Return(nil)
 			res.On("SetMutable").Return(nil)
 			res.On("ConvergingStatus", ConvergingOperationCreated).Return(ConvergingStatusWithReason{
@@ -197,7 +194,6 @@ var _ = Describe("Component Reconciler", func() {
 			res1 := &MockAliveResource{}
 			res1.On("Object").Return(cm1, nil)
 			res1.On("Identity").Return("ConfigMap/create-cm")
-			res1.On("SetObject", mock.Anything).Return(nil)
 			res1.On("SetImmutable").Return(nil)
 			res1.On("SetMutable").Return(nil)
 			res1.On("ConvergingStatus", ConvergingOperationCreated).Return(ConvergingStatusWithReason{
@@ -267,7 +263,6 @@ var _ = Describe("Component Reconciler", func() {
 			createRes := &MockResource{}
 			createRes.On("Object").Return(cm, nil)
 			createRes.On("Identity").Return("ConfigMap/should-not-be-created")
-			createRes.On("SetObject", mock.Anything).Return(nil)
 			createRes.On("SetImmutable").Return(nil)
 			createRes.On("SetMutable").Return(nil)
 
@@ -278,7 +273,6 @@ var _ = Describe("Component Reconciler", func() {
 			}, nil)
 			suspendRes.On("Identity").Return("suspend-me")
 			suspendRes.On("Suspend").Return(nil)
-			suspendRes.On("SetObject", mock.Anything).Return(nil)
 			suspendRes.On("SetImmutable").Return(nil)
 			suspendRes.On("SetMutable").Return(nil)
 			suspendRes.On("SuspensionStatus").Return(SuspensionStatusWithReason{
@@ -322,7 +316,6 @@ var _ = Describe("Component Reconciler", func() {
 			res.On("Object").Return(cm, nil)
 			res.On("Identity").Return("ConfigMap/test-suspended-cm")
 			res.On("Suspend").Return(nil)
-			res.On("SetObject", mock.Anything).Return(nil)
 			res.On("SetMutable").Return(nil)
 			res.On("SuspensionStatus").Return(SuspensionStatusWithReason{
 				Status: SuspensionStatusSuspended,
@@ -479,7 +472,6 @@ var _ = Describe("Component Reconciler", func() {
 			}, nil)
 			susRes.On("Identity").Return("suspend-ok")
 			susRes.On("Suspend").Return(nil)
-			susRes.On("SetObject", mock.Anything).Return(nil)
 			susRes.On("SetImmutable").Return(nil)
 			susRes.On("SetMutable").Return(nil)
 			susRes.On("SuspensionStatus").Return(SuspensionStatusWithReason{Status: SuspensionStatusSuspended}, nil)
@@ -515,7 +507,6 @@ var _ = Describe("Component Reconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: namespace},
 			}, nil)
 			res.On("Identity").Return("ConfigMap/test-cm")
-			res.On("SetObject", mock.Anything).Return(nil)
 			res.On("SetImmutable").Return(nil)
 			res.On("SetMutable").Return(nil)
 			res.On("ExtractData").Return(nil)
@@ -544,7 +535,6 @@ var _ = Describe("Component Reconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: namespace},
 			}, nil)
 			res.On("Identity").Return("ConfigMap/test-cm")
-			res.On("SetObject", mock.Anything).Return(nil)
 			res.On("SetImmutable").Return(nil)
 			res.On("SetMutable").Return(nil)
 			res.On("ExtractData").Return(nil)
@@ -570,7 +560,6 @@ var _ = Describe("Component Reconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: namespace},
 			}, nil)
 			res.On("Identity").Return("ConfigMap/test-cm")
-			res.On("SetObject", mock.Anything).Return(nil)
 			res.On("SetImmutable").Return(nil)
 			res.On("SetMutable").Return(nil)
 			res.On("ExtractData").Return(fmt.Errorf("extraction failed"))
@@ -596,7 +585,6 @@ var _ = Describe("Component Reconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "res1", Namespace: namespace},
 			}, nil)
 			res1.On("Identity").Return("ConfigMap/res1")
-			res1.On("SetObject", mock.Anything).Return(nil)
 			res1.On("SetImmutable").Return(nil)
 			res1.On("SetMutable").Return(nil)
 			res1.On("ExtractData").Return(nil)
@@ -606,7 +594,6 @@ var _ = Describe("Component Reconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "res2", Namespace: namespace},
 			}, nil)
 			res2.On("Identity").Return("ConfigMap/res2")
-			res2.On("SetObject", mock.Anything).Return(nil)
 			res2.On("SetImmutable").Return(nil)
 			res2.On("SetMutable").Return(nil)
 
@@ -636,7 +623,6 @@ var _ = Describe("Component Reconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "ext-cm", Namespace: namespace},
 			}, nil)
 			res.On("Identity").Return("ConfigMap/ext-cm")
-			res.On("SetObject", mock.Anything).Return(nil)
 			res.On("SetImmutable").Return(nil)
 			res.On("SetMutable").Return(nil)
 

--- a/pkg/component/create.go
+++ b/pkg/component/create.go
@@ -70,18 +70,11 @@ func createOrUpdateResources(
 
 // mutateResource is the controllerutil.MutateFn used by CreateOrUpdate.
 // It orchestrates the application of desired state to the Kubernetes object:
-//  1. Sync: Updates the resource wrapper with the current object state from the cluster.
-//  2. Immutable Fields: If the object is being created (no creation timestamp),
+//  1. Immutable Fields: If the object is being created (no creation timestamp),
 //     calls SetImmutable() to apply fields that cannot be changed later.
-//  3. Mutable Fields: Calls SetMutable() to apply updates to the desired state.
-//  4. Ownership: Ensures the object has a controller reference pointing to the owner CRD.
+//  2. Mutable Fields: Calls SetMutable() to apply updates to the desired state.
+//  3. Ownership: Ensures the object has a controller reference pointing to the owner CRD.
 func mutateResource(resource Resource, obj client.Object, owner client.Object, scheme *runtime.Scheme) error {
-	// current
-	err := resource.SetObject(obj)
-	if err != nil {
-		return fmt.Errorf("failed to set resource %w", err)
-	}
-
 	// creation
 	created := obj.GetCreationTimestamp()
 	if created.IsZero() {

--- a/pkg/component/create_test.go
+++ b/pkg/component/create_test.go
@@ -40,7 +40,6 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		}
 		resource := &MockResource{}
 		resource.On("Object").Return(resourceObject, nil)
-		resource.On("SetObject", mock.Anything).Return(nil)
 		resource.On("SetImmutable").Return(nil)
 		resource.On("SetMutable").Return(nil)
 
@@ -69,7 +68,6 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		}
 		resource1 := &MockResource{}
 		resource1.On("Object").Return(resourceObject1, nil)
-		resource1.On("SetObject", mock.Anything).Return(nil)
 		resource1.On("SetImmutable").Return(nil)
 		resource1.On("SetMutable").Return(nil)
 
@@ -81,7 +79,6 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		}
 		resource2 := &MockResource{}
 		resource2.On("Object").Return(resourceObject2, nil)
-		resource2.On("SetObject", mock.Anything).Return(nil)
 		resource2.On("SetImmutable").Return(nil)
 		resource2.On("SetMutable").Return(nil)
 
@@ -113,7 +110,6 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		}
 		regularResource := &MockResource{}
 		regularResource.On("Object").Return(regularResourceObject, nil)
-		regularResource.On("SetObject", mock.Anything).Return(nil)
 		regularResource.On("SetImmutable").Return(nil)
 		regularResource.On("SetMutable").Return(nil)
 
@@ -125,7 +121,6 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		}
 		aliveResource := &MockAliveResource{}
 		aliveResource.On("Object").Return(aliveResourceObject, nil)
-		aliveResource.On("SetObject", mock.Anything).Return(nil)
 		aliveResource.On("SetImmutable").Return(nil)
 		aliveResource.On("SetMutable").Return(nil)
 		aliveResource.On("ConvergingStatus", mock.Anything).Return(ConvergingStatusWithReason{
@@ -156,7 +151,6 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		}
 		resource1 := &MockResource{}
 		resource1.On("Object").Return(resourceObject1, nil)
-		resource1.On("SetObject", mock.Anything).Return(nil)
 		resource1.On("SetImmutable").Return(nil)
 		resource1.On("SetMutable").Return(nil)
 
@@ -201,13 +195,11 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		updatedResourceObject.Data["foo"] = "baz"
 
 		resource := &MockResource{}
-		resource.On("Object").Return(configMap.DeepCopy(), nil)
-		resource.On("SetObject", mock.Anything).Run(func(args mock.Arguments) {
-			obj := args.Get(0).(*corev1.ConfigMap)
-			obj.Data = updatedResourceObject.Data
+		resource.On("Object").Return(configMap, nil)
+		resource.On("SetImmutable").Return(nil).Maybe()
+		resource.On("SetMutable").Run(func(_ mock.Arguments) {
+			configMap.Data["foo"] = "baz"
 		}).Return(nil)
-		resource.On("SetImmutable").Return(nil).Maybe() // Depends on whether fake client returns timestamp immediately
-		resource.On("SetMutable").Return(nil)
 
 		// When
 		results, err := createOrUpdateResources(ctx, reconcileContext, []Resource{resource})
@@ -233,7 +225,6 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		}
 		resource := &MockAliveResource{}
 		resource.On("Object").Return(resourceObject, nil)
-		resource.On("SetObject", mock.Anything).Return(nil)
 		resource.On("SetImmutable").Return(nil)
 		resource.On("SetMutable").Return(nil)
 		resource.On("ConvergingStatus", mock.Anything).Return(ConvergingStatusWithReason{
@@ -277,7 +268,6 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		resource := &MockResource{}
 		resource.On("Identity").Return("v1/ConfigMap/error-cm")
 		resource.On("Object").Return(resourceObject, nil)
-		resource.On("SetObject", mock.Anything).Return(nil)
 		resource.On("SetImmutable").Return(nil)
 		resource.On("SetMutable").Return(fmt.Errorf("mutation failed"))
 
@@ -313,7 +303,6 @@ func TestMutateResource(t *testing.T) {
 				Namespace: namespace,
 			},
 		}
-		resource.On("SetObject", resourceObject).Return(nil)
 		resource.On("SetImmutable").Return(nil)
 		resource.On("SetMutable").Return(nil)
 
@@ -338,7 +327,6 @@ func TestMutateResource(t *testing.T) {
 				CreationTimestamp: now,
 			},
 		}
-		resource.On("SetObject", resourceObject).Return(nil)
 		resource.On("SetMutable").Return(nil)
 
 		// When

--- a/pkg/component/resource.go
+++ b/pkg/component/resource.go
@@ -15,9 +15,6 @@ type Resource interface {
 	// SetMutable applies mutable fields on the resource.
 	// These fields are updated every time the component is reconciled.
 	SetMutable() error
-	// SetObject sets the underlying k8s resource object.
-	// This is used to initialize the wrapper with an existing object from the cluster.
-	SetObject(object client.Object) error
 	// Object returns the underlying k8s resource object.
 	Object() (client.Object, error)
 	// Identity returns a unique identifier for the resource in the format <apiVersion>/<kind>/<name>.

--- a/pkg/component/suspend_test.go
+++ b/pkg/component/suspend_test.go
@@ -55,7 +55,6 @@ func setupMockResource(name string, status SuspensionStatus, reason string, dele
 	res.On("Identity").Return(name)
 	res.On("SuspensionStatus").Return(SuspensionStatusWithReason{Status: status, Reason: reason}, nil)
 	res.On("DeleteOnSuspend").Return(deleteOnSuspend)
-	res.On("SetObject", mock.Anything).Return(nil)
 	res.On("SetImmutable").Return(nil)
 	res.On("SetMutable").Return(nil)
 

--- a/pkg/component/zz_mock_resource_test.go
+++ b/pkg/component/zz_mock_resource_test.go
@@ -21,11 +21,6 @@ func (m *MockResource) SetMutable() error {
 	return args.Error(0)
 }
 
-func (m *MockResource) SetObject(object client.Object) error {
-	args := m.Called(object)
-	return args.Error(0)
-}
-
 func (m *MockResource) Object() (client.Object, error) {
 	args := m.Called()
 	obj := args.Get(0)


### PR DESCRIPTION
- SetObject is redundant: ctrl.CreateOrUpdate already sets the object
- Improve the example for SetImmutable in deployment_resource