### PR TITLE
fix duplicate calls to beginfeature

### DIFF
--- a/pkg/primitives/configmap/mutator.go
+++ b/pkg/primitives/configmap/mutator.go
@@ -34,8 +34,11 @@ type Mutator struct {
 
 // NewMutator creates a new Mutator for the given ConfigMap.
 func NewMutator(cm *corev1.ConfigMap) *Mutator {
-	m := &Mutator{cm: cm}
-	m.beginFeature()
+	m := &Mutator{
+		cm:    cm,
+		plans: []featurePlan{{}},
+	}
+	m.active = &m.plans[0]
 	return m
 }
 

--- a/pkg/primitives/deployment/mutator.go
+++ b/pkg/primitives/deployment/mutator.go
@@ -57,8 +57,9 @@ type Mutator struct {
 func NewMutator(current *appsv1.Deployment) *Mutator {
 	m := &Mutator{
 		current: current,
+		plans:   []featurePlan{{}},
 	}
-	m.beginFeature()
+	m.active = &m.plans[0]
 	return m
 }
 


### PR DESCRIPTION
Remove beginFeature call from NewMutator to prevent an empty feature using the mutate_helper.go function which also calls beginFeature.