### PR TITLE
forward RecordObservation on primitive resource wrappers

### DIFF
--- a/pkg/primitives/clusterrole/observation_test.go
+++ b/pkg/primitives/clusterrole/observation_test.go
@@ -1,0 +1,10 @@
+package clusterrole
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/clusterrole/resource.go
+++ b/pkg/primitives/clusterrole/resource.go
@@ -14,6 +14,7 @@ import (
 //   - component.Resource: for basic identity and mutation behaviour.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // ClusterRole resources are static: they do not model convergence health, grace periods,
 // or suspension. Use a workload or task primitive for resources that require those concepts.
@@ -55,6 +56,14 @@ func (r *Resource) Mutate(current client.Object) error {
 // component to read generated or updated values from the ClusterRole.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/clusterrolebinding/observation_test.go
+++ b/pkg/primitives/clusterrolebinding/observation_test.go
@@ -1,0 +1,10 @@
+package clusterrolebinding
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/clusterrolebinding/resource.go
+++ b/pkg/primitives/clusterrolebinding/resource.go
@@ -14,6 +14,7 @@ import (
 //   - component.Resource: for basic identity and mutation behaviour.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // ClusterRoleBinding resources are static: they do not model convergence health,
 // grace periods, or suspension. Use a workload or task primitive for resources
@@ -55,6 +56,14 @@ func (r *Resource) Mutate(current client.Object) error {
 // component to read generated or updated values from the ClusterRoleBinding.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/configmap/observation_test.go
+++ b/pkg/primitives/configmap/observation_test.go
@@ -1,0 +1,10 @@
+package configmap
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/configmap/resource.go
+++ b/pkg/primitives/configmap/resource.go
@@ -14,6 +14,7 @@ import (
 //   - component.Resource: for basic identity and mutation behaviour.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // ConfigMap resources are static: they do not model convergence health, grace periods,
 // or suspension. Use a workload or task primitive for resources that require those concepts.
@@ -53,6 +54,14 @@ func (r *Resource) Mutate(current client.Object) error {
 // component to read generated or updated values from the ConfigMap.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/cronjob/observation_test.go
+++ b/pkg/primitives/cronjob/observation_test.go
@@ -1,0 +1,10 @@
+package cronjob
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/cronjob/resource.go
+++ b/pkg/primitives/cronjob/resource.go
@@ -18,6 +18,7 @@ import (
 //   - concepts.Suspendable: for controlled suspension via spec.suspend.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting information after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 type Resource struct {
 	base *generic.IntegrationResource[*batchv1.CronJob, *Mutator]
 }
@@ -90,6 +91,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // from the reconciled CronJob.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/daemonset/observation_test.go
+++ b/pkg/primitives/daemonset/observation_test.go
@@ -1,0 +1,10 @@
+package daemonset
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/daemonset/resource.go
+++ b/pkg/primitives/daemonset/resource.go
@@ -16,6 +16,7 @@ import (
 //   - concepts.Suspendable: for graceful deactivation via deletion.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting information after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // This resource handles the lifecycle of a DaemonSet, including initial creation,
 // updates via feature mutations, and status monitoring.
@@ -121,6 +122,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // by other resources or higher-level controllers.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/deployment/observation_test.go
+++ b/pkg/primitives/deployment/observation_test.go
@@ -1,0 +1,10 @@
+package deployment
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/deployment/resource.go
+++ b/pkg/primitives/deployment/resource.go
@@ -16,6 +16,7 @@ import (
 //   - concepts.Suspendable: for graceful scale-down or temporary deactivation.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting information after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // This resource handles the lifecycle of a Deployment, including initial creation,
 // updates via feature mutations, and status monitoring.
@@ -137,6 +138,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // prevent accidental mutations during the extraction process.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/hpa/observation_test.go
+++ b/pkg/primitives/hpa/observation_test.go
@@ -1,0 +1,10 @@
+package hpa
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/hpa/resource.go
+++ b/pkg/primitives/hpa/resource.go
@@ -18,6 +18,7 @@ import (
 //     prevent it from scaling the target back up during suspension.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 type Resource struct {
 	base *generic.IntegrationResource[*autoscalingv2.HorizontalPodAutoscaler, *Mutator]
 }
@@ -94,6 +95,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // component to read generated or updated values from the HPA.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/ingress/observation_test.go
+++ b/pkg/primitives/ingress/observation_test.go
@@ -1,0 +1,10 @@
+package ingress
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/ingress/resource.go
+++ b/pkg/primitives/ingress/resource.go
@@ -18,6 +18,7 @@ import (
 //   - concepts.Suspendable: for controlled suspension when the parent component is suspended.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // Ingress resources are integration primitives: they depend on an external ingress
 // controller to assign load balancer addresses. The default operational status handler
@@ -108,6 +109,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // addresses) from the Ingress.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/job/observation_test.go
+++ b/pkg/primitives/job/observation_test.go
@@ -1,0 +1,10 @@
+package job
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/job/resource.go
+++ b/pkg/primitives/job/resource.go
@@ -16,6 +16,7 @@ import (
 //   - concepts.Suspendable: for controlled deactivation (suspend or delete).
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting information after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // This resource handles the lifecycle of a Job, including initial creation,
 // updates via feature mutations, and completion status monitoring.
@@ -121,6 +122,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // prevent accidental mutations during the extraction process.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/networkpolicy/observation_test.go
+++ b/pkg/primitives/networkpolicy/observation_test.go
@@ -1,0 +1,10 @@
+package networkpolicy
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/networkpolicy/resource.go
+++ b/pkg/primitives/networkpolicy/resource.go
@@ -14,6 +14,7 @@ import (
 //   - component.Resource: for basic identity and mutation behaviour.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // NetworkPolicy resources are static: they do not model convergence health, grace
 // periods, or suspension. Use a workload or task primitive for resources that
@@ -55,6 +56,14 @@ func (r *Resource) Mutate(current client.Object) error {
 // component to read generated or updated values from the NetworkPolicy.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/pdb/observation_test.go
+++ b/pkg/primitives/pdb/observation_test.go
@@ -1,0 +1,10 @@
+package pdb
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/pdb/resource.go
+++ b/pkg/primitives/pdb/resource.go
@@ -15,6 +15,7 @@ import (
 //   - component.Resource: for basic identity and mutation behaviour.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // PodDisruptionBudget resources are static: they do not model convergence health,
 // grace periods, or suspension. Use a workload or task primitive for resources
@@ -55,6 +56,14 @@ func (r *Resource) Mutate(current client.Object) error {
 // component to read generated or updated values from the PodDisruptionBudget.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/pod/observation_test.go
+++ b/pkg/primitives/pod/observation_test.go
@@ -1,0 +1,10 @@
+package pod
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/pod/resource.go
+++ b/pkg/primitives/pod/resource.go
@@ -16,6 +16,7 @@ import (
 //   - concepts.Suspendable: for deletion-based deactivation.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting information after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // This resource handles the lifecycle of a Pod, including initial creation,
 // updates via feature mutations, and status monitoring.
@@ -121,6 +122,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // prevent accidental mutations during the extraction process.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/pv/observation_test.go
+++ b/pkg/primitives/pv/observation_test.go
@@ -1,0 +1,10 @@
+package pv
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/pv/resource.go
+++ b/pkg/primitives/pv/resource.go
@@ -16,6 +16,7 @@ import (
 //   - concepts.Graceful: for assessing health after the grace period expires.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 type Resource struct {
 	base *generic.IntegrationResource[*corev1.PersistentVolume, *Mutator]
 }
@@ -72,6 +73,14 @@ func (r *Resource) GraceStatus() (concepts.GraceStatusWithReason, error) {
 // component to read generated or updated values from the PV.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/pvc/observation_test.go
+++ b/pkg/primitives/pvc/observation_test.go
@@ -1,0 +1,10 @@
+package pvc
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/pvc/resource.go
+++ b/pkg/primitives/pvc/resource.go
@@ -17,6 +17,7 @@ import (
 //   - concepts.Suspendable: for controlled suspension (e.g. retaining the PVC while suspending consumers).
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // PVC resources follow the Integration lifecycle: they are operationally significant
 // (a PVC must be Bound to be useful) and support suspension semantics.
@@ -102,6 +103,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // component to read generated or updated values from the PVC.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/replicaset/observation_test.go
+++ b/pkg/primitives/replicaset/observation_test.go
@@ -1,0 +1,10 @@
+package replicaset
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/replicaset/resource.go
+++ b/pkg/primitives/replicaset/resource.go
@@ -16,6 +16,7 @@ import (
 //   - concepts.Suspendable: for graceful scale-down or temporary deactivation.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting information after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // This resource handles the lifecycle of a ReplicaSet, including initial creation,
 // updates via feature mutations, and status monitoring.
@@ -115,6 +116,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // prevent accidental mutations during the extraction process.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/role/observation_test.go
+++ b/pkg/primitives/role/observation_test.go
@@ -1,0 +1,10 @@
+package role
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/role/resource.go
+++ b/pkg/primitives/role/resource.go
@@ -15,6 +15,7 @@ import (
 //   - component.Resource: for basic identity and mutation behaviour.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // Role resources are static: they do not model convergence health, grace periods,
 // or suspension. Use a workload or task primitive for resources that require those concepts.
@@ -54,6 +55,14 @@ func (r *Resource) Mutate(current client.Object) error {
 // component to read generated or updated values from the Role.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/rolebinding/observation_test.go
+++ b/pkg/primitives/rolebinding/observation_test.go
@@ -1,0 +1,10 @@
+package rolebinding
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/rolebinding/resource.go
+++ b/pkg/primitives/rolebinding/resource.go
@@ -14,6 +14,7 @@ import (
 //   - component.Resource: for basic identity and mutation behaviour.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // RoleBinding resources are static: they do not model convergence health,
 // grace periods, or suspension.
@@ -50,6 +51,14 @@ func (r *Resource) Mutate(current client.Object) error {
 // component to read generated or updated values from the RoleBinding.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/secret/observation_test.go
+++ b/pkg/primitives/secret/observation_test.go
@@ -1,0 +1,79 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)
+
+// TestReadOnlyExtractor_ObservesClusterState reproduces the user-reported
+// scenario from issue #115 / #118 end-to-end against a real *Resource: build
+// the Resource via the public builder, fetch it through a fake client, hand
+// the fetched object to the framework's RecordObservation hook, run
+// ExtractData, and assert that the registered extractor sees the live cluster
+// data rather than the inert base used to construct the resource.
+//
+// The framework-side wiring is covered by pkg/component/read_test.go using
+// mock resources; this test exercises the same chain through a real primitive,
+// so a regression in either the wrapper's forwarding or the BaseResource
+// implementation is caught here.
+func TestReadOnlyExtractor_ObservesClusterState(t *testing.T) {
+	ctx := t.Context()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	clusterSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "creds",
+			Namespace: "ns",
+		},
+		Data: map[string][]byte{"token": []byte("from-cluster")},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(clusterSecret).
+		Build()
+
+	base := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "creds",
+			Namespace: "ns",
+		},
+	}
+
+	var captured []byte
+	res, err := NewBuilder(base).
+		WithDataExtractor(func(s corev1.Secret) error {
+			captured = s.Data["token"]
+			return nil
+		}).
+		Build()
+	require.NoError(t, err)
+
+	// Simulate the framework's read flow: deep-copy the desired base, fetch
+	// the cluster state into it, record the observation, run extraction.
+	fetched, err := res.Object()
+	require.NoError(t, err)
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(fetched), fetched))
+
+	require.NoError(t, res.RecordObservation(fetched))
+	require.NoError(t, res.ExtractData())
+
+	assert.Equal(t, []byte("from-cluster"), captured,
+		"the extractor must see the cluster's Secret data, not the empty base")
+}

--- a/pkg/primitives/secret/resource.go
+++ b/pkg/primitives/secret/resource.go
@@ -14,6 +14,7 @@ import (
 //   - component.Resource: for basic identity and mutation behaviour.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // Secret resources are static: they do not model convergence health, grace periods,
 // or suspension. Use a workload or task primitive for resources that require those concepts.
@@ -53,6 +54,14 @@ func (r *Resource) Mutate(current client.Object) error {
 // component to read generated or updated values from the Secret.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only Secrets after
+// fetching them so that registered data extractors observe the live Secret rather
+// than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/service/observation_test.go
+++ b/pkg/primitives/service/observation_test.go
@@ -1,0 +1,10 @@
+package service
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/service/resource.go
+++ b/pkg/primitives/service/resource.go
@@ -57,6 +57,7 @@ func normalizeProtocol(p corev1.Protocol) corev1.Protocol {
 //   - concepts.Suspendable: for participating in the component suspension lifecycle.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 type Resource struct {
 	base *generic.IntegrationResource[*corev1.Service, *Mutator]
 }
@@ -135,6 +136,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // LoadBalancer ingress from the Service.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/serviceaccount/observation_test.go
+++ b/pkg/primitives/serviceaccount/observation_test.go
@@ -1,0 +1,10 @@
+package serviceaccount
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/serviceaccount/resource.go
+++ b/pkg/primitives/serviceaccount/resource.go
@@ -14,6 +14,7 @@ import (
 //   - component.Resource: for basic identity and mutation behaviour.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // ServiceAccount resources are static: they do not model convergence health, grace periods,
 // or suspension. Use a workload or task primitive for resources that require those concepts.
@@ -53,6 +54,14 @@ func (r *Resource) Mutate(current client.Object) error {
 // component to read generated or updated values from the ServiceAccount.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/statefulset/observation_test.go
+++ b/pkg/primitives/statefulset/observation_test.go
@@ -1,0 +1,10 @@
+package statefulset
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/statefulset/resource.go
+++ b/pkg/primitives/statefulset/resource.go
@@ -16,6 +16,7 @@ import (
 //   - concepts.Suspendable: for graceful scale-down or temporary deactivation.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting information after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // This resource handles the lifecycle of a StatefulSet, including initial creation,
 // updates via feature mutations, and status monitoring.
@@ -118,6 +119,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // other resources or higher-level controllers.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/unstructured/integration/observation_test.go
+++ b/pkg/primitives/unstructured/integration/observation_test.go
@@ -1,0 +1,10 @@
+package integration
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/unstructured/integration/resource.go
+++ b/pkg/primitives/unstructured/integration/resource.go
@@ -21,6 +21,7 @@ import (
 //   - concepts.Suspendable: for graceful deactivation.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // The operational status handler is required. All other handlers default to
 // safe no-ops when omitted.
@@ -78,6 +79,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // copy of the reconciled object.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/unstructured/static/observation_test.go
+++ b/pkg/primitives/unstructured/static/observation_test.go
@@ -1,0 +1,10 @@
+package static
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/unstructured/static/resource.go
+++ b/pkg/primitives/unstructured/static/resource.go
@@ -18,6 +18,7 @@ import (
 //   - component.Resource: for basic identity and mutation behaviour.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // Static unstructured resources do not model convergence health, grace periods,
 // or suspension. Use the workload, integration, or task unstructured variants
@@ -47,6 +48,14 @@ func (r *Resource) Mutate(current client.Object) error {
 // copy of the reconciled object.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/unstructured/task/observation_test.go
+++ b/pkg/primitives/unstructured/task/observation_test.go
@@ -1,0 +1,10 @@
+package task
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/unstructured/task/resource.go
+++ b/pkg/primitives/unstructured/task/resource.go
@@ -19,6 +19,7 @@ import (
 //   - concepts.Suspendable: for graceful deactivation.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // The converging status handler is required; all other handlers default to
 // safe no-ops when omitted.
@@ -70,6 +71,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // copy of the reconciled object.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.

--- a/pkg/primitives/unstructured/workload/observation_test.go
+++ b/pkg/primitives/unstructured/workload/observation_test.go
@@ -1,0 +1,10 @@
+package workload
+
+import "github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+
+// The framework discovers read-only data-extraction support by type-asserting
+// the registered Resource to concepts.ObservationRecorder. Because the wrapper
+// holds its base resource behind a named (non-embedded) field, the
+// RecordObservation method must be forwarded explicitly. This compile-time
+// check guards against silent regressions of issue #118.
+var _ concepts.ObservationRecorder = (*Resource)(nil)

--- a/pkg/primitives/unstructured/workload/resource.go
+++ b/pkg/primitives/unstructured/workload/resource.go
@@ -21,6 +21,7 @@ import (
 //   - concepts.Suspendable: for graceful scale-down or temporary deactivation.
 //   - concepts.Guardable: for conditional reconciliation based on a guard precondition.
 //   - concepts.DataExtractable: for exporting values after successful reconciliation.
+//   - concepts.ObservationRecorder: for surfacing live cluster state to data extractors on read-only reconciliation.
 //
 // The converging status handler is required; all other handlers default to
 // safe no-ops when omitted.
@@ -78,6 +79,14 @@ func (r *Resource) SuspensionStatus() (concepts.SuspensionStatusWithReason, erro
 // copy of the reconciled object.
 func (r *Resource) ExtractData() error {
 	return r.base.ExtractData()
+}
+
+// RecordObservation stores the supplied object as the resource's most recently
+// observed cluster state. The framework invokes this on read-only resources
+// after fetching them so that registered data extractors observe the live
+// object rather than the inert base used to construct the resource.
+func (r *Resource) RecordObservation(observed client.Object) error {
+	return r.base.RecordObservation(observed)
 }
 
 // GuardStatus evaluates the resource's guard precondition.


### PR DESCRIPTION
## Summary

- The v0.9.0 fix for #115 dispatches to `concepts.ObservationRecorder` via a runtime type assertion in `pkg/component/read.go`. Every primitive's `Resource` wrapper holds the generic resource behind an unexported named field instead of embedding it, so methods are not promoted onto the wrapper. The assertion therefore failed for every primitive in `pkg/primitives`, the fetched object was never recorded, and read-only data extractors continued to see the inert base used to build the resource. The original #115 scenario (secret rotation hash always equal to `sha256("{}")`) reproduces against v0.9.0 for every primitive. Documented in #118.
- Forward `RecordObservation` explicitly on every primitive `Resource` type (21 typed primitives plus the 4 unstructured variants), mirroring how `ExtractData` and `GuardStatus` are forwarded.
- Lock in the invariant with a per-primitive compile-time assertion (`var _ concepts.ObservationRecorder = (*Resource)(nil)`) in a dedicated `observation_test.go` file per package. A future primitive that forgets to forward the method fails to build instead of regressing silently. This also extends naturally to any future framework type-assertion dispatch.
- Add a primitive-level end-to-end test in `pkg/primitives/secret/observation_test.go` that builds a real `*Resource` with `WithDataExtractor`, fetches a populated cluster Secret through a fake client, calls `RecordObservation` and `ExtractData`, and asserts the extractor observes the fetched data. This catches both forwarder-missing (would have been caught by compile-time check too) and forwarder-broken (would not) regressions for the canonical user-reported scenario.

Closes #118.

## Test plan

- [x] `make all` clean.
- [x] `TestReadOnlyExtractor_ObservesClusterState` in `pkg/primitives/secret` passes against the fix; would have caught v0.9.0 at compile time (missing method) and at runtime if the forwarder were broken.
- [x] Compile-time `var _ concepts.ObservationRecorder = (*Resource)(nil)` in every primitive's `observation_test.go` ensures the bug cannot silently regress in any of the 25 primitives.

## Notes

We considered switching every primitive wrapper to anonymously embed its generic resource (option 3 in the issue analysis), which would promote `RecordObservation` automatically and immunise the framework against future type-assertion-dispatch surprises. Rejected for this PR because it would expose the generic `BaseResource`'s exported fields (`DesiredObject`, `GuardHandler`, etc.) as part of every primitive's public API. Worth revisiting if and when those fields are made unexported or moved behind constructor-only access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)