### PR TITLE
Add cluster-free component preview for whole-component golden tests

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -17,6 +17,7 @@ reports their aggregate health through one condition on the owner CRD.
   - [Prerequisite Behavior](#prerequisite-behavior)
   - [Status Reporting](#status-reporting)
 - [Reconciliation Lifecycle](#reconciliation-lifecycle)
+- [Previewing Desired State](#previewing-desired-state)
 - [Cluster-Scoped Resources](#cluster-scoped-resources)
 - [Status Model](#status-model)
   - [Alive Resources](#alive-resources-alive-interface)
@@ -275,6 +276,45 @@ calls the Kubernetes API to persist status; the controller does that in a single
 See [Persisting Status with FlushStatus](#persisting-status-with-flushstatus).
 
 **Phase 6: Resource deletion.** Resources registered for deletion are removed from the cluster.
+
+## Previewing Desired State
+
+`Component.Preview() ([]client.Object, error)` renders the desired state of every managed resource the component would
+apply, in registration order, without contacting the cluster. Read-only resources (fetched, not applied) and delete
+resources (removal markers) are excluded.
+
+Each managed resource must implement `concepts.Previewable`. All built-in primitives satisfy this through
+`generic.BaseResource`. `Preview` returns an error if any managed resource does not implement `concepts.Previewable` or
+if rendering a resource fails.
+
+`Component.Resource(identity string) (Resource, bool)` looks up a registered resource by its `Identity()` string. The
+identity format is `<apiVersion>/<kind>/<namespace>/<name>`. The lookup covers all registered resources: managed,
+read-only, and delete resources.
+
+`Reconcile` remains the only path that performs cluster IO. `Preview` is the natural input for whole-component golden
+snapshots via `golden.AssertComponentYAML`.
+
+```go
+comp, err := buildWebComponent(owner)
+if err != nil {
+    return err
+}
+
+objs, err := comp.Preview()
+if err != nil {
+    return err
+}
+
+for _, obj := range objs {
+    fmt.Printf("%s/%s\n", obj.GetNamespace(), obj.GetName())
+}
+```
+
+If you need the concrete Kubernetes type rather than `client.Object`, type-assert the returned value:
+
+```go
+dep, ok := objs[0].(*appsv1.Deployment)
+```
 
 ## Cluster-Scoped Resources
 

--- a/docs/component.md
+++ b/docs/component.md
@@ -279,17 +279,25 @@ See [Persisting Status with FlushStatus](#persisting-status-with-flushstatus).
 
 ## Previewing Desired State
 
-`Component.Preview() ([]client.Object, error)` renders the desired state of every managed resource the component would
-apply, in registration order, without contacting the cluster. Read-only resources (fetched, not applied) and delete
+`Component.Preview() ([]client.Object, error)` renders the desired state of every managed resource registered on the
+component, in registration order, without contacting the cluster. Read-only resources (fetched, not applied) and delete
 resources (removal markers) are excluded.
+
+`Preview` does not evaluate guards. Reconciliation stops at the first resource whose guard is `Blocked` and skips that
+resource and all later ones, but a guard's outcome typically depends on cluster state and data extracted from earlier
+resources, neither of which is available in a cluster-free render. `Preview` therefore reports the full desired shape of
+every managed resource, including ones a given reconcile might skip behind a blocked guard. This keeps the snapshot
+deterministic and focused on baseline construction, mutation wiring, and registration order.
 
 Each managed resource must implement `concepts.Previewable`. All built-in primitives satisfy this through
 `generic.BaseResource`. `Preview` returns an error if any managed resource does not implement `concepts.Previewable` or
 if rendering a resource fails.
 
-`Component.Resource(identity string) (Resource, bool)` looks up a registered resource by its `Identity()` string. The
-identity format is `<apiVersion>/<kind>/<namespace>/<name>`. The lookup covers all registered resources: managed,
-read-only, and delete resources.
+`Component.Resource(identity string) (Resource, bool)` looks up a registered resource by its `Identity()` string. For
+namespaced resources the identity is `<apiVersion>/<kind>/<namespace>/<name>` (for example
+`apps/v1/Deployment/default/web`); cluster-scoped resources omit the namespace segment (for example
+`v1/PersistentVolume/data` or `rbac.authorization.k8s.io/v1/ClusterRole/viewer`). The lookup covers all registered
+resources: managed, read-only, and delete resources.
 
 `Reconcile` remains the only path that performs cluster IO. `Preview` is the natural input for whole-component golden
 snapshots via `golden.AssertComponentYAML`.

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -211,8 +211,8 @@ gated on the versions that need it, and will stop running entirely once those ve
 ### Verifying backward compatibility mutations
 
 When you update the baseline, you need confidence that older versions still produce the same object they did before. The
-framework provides a `golden` package for this. `AssertYAML` accepts any resource that implements `PreviewObject`,
-renders it to YAML, and compares the result against a golden file.
+framework provides a `golden` package for this. `AssertYAML` accepts any resource that implements `Preview`, renders it
+to YAML, and compares the result against a golden file.
 
 ```go
 import "github.com/sourcehawk/operator-component-framework/pkg/testing/golden"
@@ -251,6 +251,27 @@ snapshot diff shows exactly what shifted.
 
 A reasonable heuristic for the boundary: if a field is always present regardless of feature flags or version, it belongs
 in the baseline. If it is conditional, it belongs in a mutation.
+
+To snapshot an entire component at once, use `AssertComponentYAML`. It calls `comp.Preview()`, serializes every managed
+resource the component would apply into a single multi-document YAML file (one `---` separator per object, in
+registration order), and compares the result against the golden file. This is useful when you want to verify that a
+cross-component change does not accidentally alter any resource's shape.
+
+```go
+func TestComponentShape(t *testing.T) {
+    owner := &v1alpha1.MyApp{
+        Spec: v1alpha1.MyAppSpec{Version: "2.0.0"},
+    }
+
+    comp, err := buildWebComponent(owner)
+    require.NoError(t, err)
+
+    golden.AssertComponentYAML(t, "testdata/web-component.yaml", comp, golden.Update(*update))
+}
+```
+
+Read-only and delete resources are excluded from the component preview; only resources the component would actively
+apply appear in the golden file.
 
 ## One Component Per Logical Condition
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -253,7 +253,7 @@ A reasonable heuristic for the boundary: if a field is always present regardless
 in the baseline. If it is conditional, it belongs in a mutation.
 
 To snapshot an entire component at once, use `AssertComponentYAML`. It calls `comp.Preview()`, serializes every managed
-resource the component would apply into a single multi-document YAML file (one `---` separator per object, in
+resource the component would apply into a single multi-document YAML file (documents joined by `---` separators, in
 registration order), and compares the result against the golden file. This is useful when you want to verify that a
 cross-component change does not accidentally alter any resource's shape.
 

--- a/examples/custom-resource/resources/certificate_test.go
+++ b/examples/custom-resource/resources/certificate_test.go
@@ -86,7 +86,7 @@ func TestCertificateGVK(t *testing.T) {
 }
 
 // Verify the Previewer interface conformance for the unstructured static resource.
-func TestCertificatePreviewObject(t *testing.T) {
+func TestCertificatePreview(t *testing.T) {
 	owner := testOwner()
 	res, err := static.NewBuilder(resources.BaseCertificateRequest(owner)).Build()
 	require.NoError(t, err)

--- a/examples/custom-resource/resources/certificate_test.go
+++ b/examples/custom-resource/resources/certificate_test.go
@@ -91,7 +91,7 @@ func TestCertificatePreviewObject(t *testing.T) {
 	res, err := static.NewBuilder(resources.BaseCertificateRequest(owner)).Build()
 	require.NoError(t, err)
 
-	obj, err := res.PreviewObject()
+	obj, err := res.Preview()
 	require.NoError(t, err)
 	require.IsType(t, &uns.Unstructured{}, obj)
 }

--- a/examples/mutations-and-gating/features/debug_logging_test.go
+++ b/examples/mutations-and-gating/features/debug_logging_test.go
@@ -33,8 +33,11 @@ func TestDebugLoggingMutation(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	obj, err := res.PreviewObject()
+	previewed, err := res.Preview()
 	require.NoError(t, err)
+
+	obj, ok := previewed.(*appsv1.Deployment)
+	require.True(t, ok)
 
 	containers := obj.Spec.Template.Spec.Containers
 	require.Len(t, containers, 1)

--- a/examples/mutations-and-gating/features/legacy_container_test.go
+++ b/examples/mutations-and-gating/features/legacy_container_test.go
@@ -39,8 +39,11 @@ func TestBackwardCompatV1Container(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	obj, err := res.PreviewObject()
+	previewed, err := res.Preview()
 	require.NoError(t, err)
+
+	obj, ok := previewed.(*appsv1.Deployment)
+	require.True(t, ok)
 
 	containers := obj.Spec.Template.Spec.Containers
 	require.Len(t, containers, 1)

--- a/examples/mutations-and-gating/features/metrics_config_test.go
+++ b/examples/mutations-and-gating/features/metrics_config_test.go
@@ -26,8 +26,11 @@ func TestMetricsConfigMutation(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	obj, err := res.PreviewObject()
+	previewed, err := res.Preview()
 	require.NoError(t, err)
+
+	obj, ok := previewed.(*corev1.ConfigMap)
+	require.True(t, ok)
 
 	yaml := obj.Data["app.yaml"]
 	assert.Contains(t, yaml, "metrics:")

--- a/examples/mutations-and-gating/features/tracing_sidecar_test.go
+++ b/examples/mutations-and-gating/features/tracing_sidecar_test.go
@@ -33,8 +33,11 @@ func TestTracingSidecarMutation(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	obj, err := res.PreviewObject()
+	previewed, err := res.Preview()
 	require.NoError(t, err)
+
+	obj, ok := previewed.(*appsv1.Deployment)
+	require.True(t, ok)
 
 	containers := obj.Spec.Template.Spec.Containers
 	require.Len(t, containers, 2)

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -16,6 +16,7 @@ import (
 
 	ocm "github.com/sourcehawk/go-crd-condition-metrics/pkg/crd-condition-metrics"
 
+	"github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
 	"github.com/sourcehawk/operator-component-framework/pkg/feature"
 )
 
@@ -135,6 +136,46 @@ func (c *Component) GetCondition(owner OperatorCRD) Condition {
 	}
 
 	return Condition(*cond)
+}
+
+// Preview renders the desired state of every managed resource the component
+// would apply, in registration order, without contacting the cluster.
+//
+// Read-only resources (which are fetched, not applied) and delete resources
+// (removal markers with no desired object) are excluded; the result is the
+// "what would you apply" view, suitable for whole-component golden snapshots.
+//
+// Each managed reconcile resource must implement concepts.Previewable; all
+// built-in primitives do. Preview returns an error if a managed resource does
+// not implement it or if rendering a resource fails.
+func (c *Component) Preview() ([]client.Object, error) {
+	objs := make([]client.Object, 0, len(c.reconcileResources))
+	for _, entry := range c.reconcileResources {
+		if entry.Options.ReadOnly {
+			continue
+		}
+		previewable, ok := entry.Resource.(concepts.Previewable)
+		if !ok {
+			return nil, fmt.Errorf(
+				"resource %q does not implement concepts.Previewable and cannot be previewed",
+				entry.Resource.Identity(),
+			)
+		}
+		obj, err := previewable.Preview()
+		if err != nil {
+			return nil, fmt.Errorf("preview resource %q: %w", entry.Resource.Identity(), err)
+		}
+		objs = append(objs, obj)
+	}
+	return objs, nil
+}
+
+// Resource returns the registered resource with the given Identity() and true,
+// or nil and false if no such resource is registered. The lookup covers every
+// registered resource, including read-only and delete resources.
+func (c *Component) Resource(identity string) (Resource, bool) {
+	r, ok := c.resourceLookup[identity]
+	return r, ok
 }
 
 // Reconcile converges the component to the desired state.

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -138,16 +138,23 @@ func (c *Component) GetCondition(owner OperatorCRD) Condition {
 	return Condition(*cond)
 }
 
-// Preview renders the desired state of every managed resource the component
-// would apply, in registration order, without contacting the cluster.
+// Preview renders the desired state of every managed resource registered on the
+// component, in registration order, without contacting the cluster.
 //
 // Read-only resources (which are fetched, not applied) and delete resources
-// (removal markers with no desired object) are excluded; the result is the
-// "what would you apply" view, suitable for whole-component golden snapshots.
+// (removal markers with no desired object) are excluded, leaving the desired
+// shape of the managed resources, suitable for whole-component golden snapshots.
+//
+// Preview does not evaluate guards. Reconcile stops at the first resource whose
+// guard is Blocked and skips it and all later resources, but a guard's outcome
+// generally depends on cluster state and data extracted from earlier resources,
+// none of which is available in a cluster-free render. Preview therefore returns
+// the full desired set, including resources a given reconcile might skip behind a
+// blocked guard, keeping the snapshot deterministic.
 //
 // Each managed reconcile resource must implement concepts.Previewable; all
 // built-in primitives do. Preview returns an error if a managed resource does
-// not implement it or if rendering a resource fails.
+// not implement it, renders a nil object, or fails to render.
 func (c *Component) Preview() ([]client.Object, error) {
 	objs := make([]client.Object, 0, len(c.reconcileResources))
 	for _, entry := range c.reconcileResources {

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -165,6 +165,9 @@ func (c *Component) Preview() ([]client.Object, error) {
 		if err != nil {
 			return nil, fmt.Errorf("preview resource %q: %w", entry.Resource.Identity(), err)
 		}
+		if obj == nil {
+			return nil, fmt.Errorf("preview resource %q: returned a nil object", entry.Resource.Identity())
+		}
 		objs = append(objs, obj)
 	}
 	return objs, nil

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -1650,6 +1650,22 @@ func TestComponentPreview(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "apps/v1/Deployment/default/f")
 	})
+
+	t.Run("errors when a managed resource previews a nil object", func(t *testing.T) {
+		nilRes := &MockPreviewableResource{}
+		nilRes.On("Identity").Return("apps/v1/Deployment/default/nilobj")
+		nilRes.On("Preview").Return(nil, nil)
+
+		b := NewComponentBuilder()
+		b.WithName("t").WithConditionType("Ready")
+		b.WithResource(nilRes, ResourceOptions{})
+		comp, err := b.Build()
+		require.NoError(t, err)
+
+		_, err = comp.Preview()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "apps/v1/Deployment/default/nilobj")
+	})
 }
 
 func TestComponentResource(t *testing.T) {

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -3,16 +3,20 @@ package component
 import (
 	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 var _ = Describe("Component Reconciler", func() {
@@ -1559,4 +1563,119 @@ type testPrereqFunc struct {
 
 func (p *testPrereqFunc) Check(_ ReconcileContext) (PrerequisiteResult, error) {
 	return p.checkFn()
+}
+
+func TestComponentPreview(t *testing.T) {
+	t.Run("renders managed reconcile resources in registration order", func(t *testing.T) {
+		r1 := &MockPreviewableResource{}
+		r1.On("Identity").Return("apps/v1/Deployment/default/a")
+		r1.On("Preview").Return(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "a"},
+		}, nil)
+
+		r2 := &MockPreviewableResource{}
+		r2.On("Identity").Return("v1/ConfigMap/default/b")
+		r2.On("Preview").Return(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "b"},
+		}, nil)
+
+		b := NewComponentBuilder()
+		b.WithName("t").WithConditionType("Ready")
+		b.WithResource(r1, ResourceOptions{})
+		b.WithResource(r2, ResourceOptions{})
+		comp, err := b.Build()
+		require.NoError(t, err)
+
+		objs, err := comp.Preview()
+		require.NoError(t, err)
+		require.Len(t, objs, 2)
+		assert.Equal(t, "a", objs[0].GetName())
+		assert.Equal(t, "b", objs[1].GetName())
+	})
+
+	t.Run("excludes read-only and delete resources", func(t *testing.T) {
+		managed := &MockPreviewableResource{}
+		managed.On("Identity").Return("apps/v1/Deployment/default/m")
+		managed.On("Preview").Return(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "m"}}, nil)
+
+		readOnly := &MockPreviewableResource{}
+		readOnly.On("Identity").Return("v1/Secret/default/ro")
+
+		del := &MockPreviewableResource{}
+		del.On("Identity").Return("v1/ConfigMap/default/del")
+
+		b := NewComponentBuilder()
+		b.WithName("t").WithConditionType("Ready")
+		b.WithResource(managed, ResourceOptions{})
+		b.WithResource(readOnly, ResourceOptions{ReadOnly: true})
+		b.WithResource(del, ResourceOptions{Delete: true})
+		comp, err := b.Build()
+		require.NoError(t, err)
+
+		objs, err := comp.Preview()
+		require.NoError(t, err)
+		require.Len(t, objs, 1)
+		assert.Equal(t, "m", objs[0].GetName())
+		readOnly.AssertNotCalled(t, "Preview")
+		del.AssertNotCalled(t, "Preview")
+	})
+
+	t.Run("errors when a managed resource is not previewable", func(t *testing.T) {
+		plain := &MockResource{} // implements Resource but not Previewable
+		plain.On("Identity").Return("apps/v1/Deployment/default/p")
+
+		b := NewComponentBuilder()
+		b.WithName("t").WithConditionType("Ready")
+		b.WithResource(plain, ResourceOptions{})
+		comp, err := b.Build()
+		require.NoError(t, err)
+
+		_, err = comp.Preview()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "apps/v1/Deployment/default/p")
+	})
+
+	t.Run("wraps a render error with the resource identity", func(t *testing.T) {
+		failing := &MockPreviewableResource{}
+		failing.On("Identity").Return("apps/v1/Deployment/default/f")
+		failing.On("Preview").Return(nil, assert.AnError)
+
+		b := NewComponentBuilder()
+		b.WithName("t").WithConditionType("Ready")
+		b.WithResource(failing, ResourceOptions{})
+		comp, err := b.Build()
+		require.NoError(t, err)
+
+		_, err = comp.Preview()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "apps/v1/Deployment/default/f")
+	})
+}
+
+func TestComponentResource(t *testing.T) {
+	managed := &MockResource{}
+	managed.On("Identity").Return("apps/v1/Deployment/default/m")
+	readOnly := &MockResource{}
+	readOnly.On("Identity").Return("v1/Secret/default/ro")
+	del := &MockResource{}
+	del.On("Identity").Return("v1/ConfigMap/default/del")
+
+	b := NewComponentBuilder()
+	b.WithName("t").WithConditionType("Ready")
+	b.WithResource(managed, ResourceOptions{})
+	b.WithResource(readOnly, ResourceOptions{ReadOnly: true})
+	b.WithResource(del, ResourceOptions{Delete: true})
+	comp, err := b.Build()
+	require.NoError(t, err)
+
+	got, ok := comp.Resource("v1/Secret/default/ro")
+	assert.True(t, ok)
+	assert.Equal(t, readOnly, got)
+
+	gotDel, ok := comp.Resource("v1/ConfigMap/default/del")
+	assert.True(t, ok)
+	assert.Equal(t, del, gotDel)
+
+	_, ok = comp.Resource("does/not/exist")
+	assert.False(t, ok)
 }

--- a/pkg/component/concepts/previewable.go
+++ b/pkg/component/concepts/previewable.go
@@ -1,0 +1,16 @@
+package concepts
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+// Previewable is implemented by resources that can render their post-mutation
+// desired state as a client.Object without contacting the cluster.
+//
+// All built-in primitives satisfy this through generic.BaseResource. The
+// component uses it to assemble a cluster-free preview of every managed resource
+// it would apply (see the component package's Component.Preview).
+type Previewable interface {
+	// Preview renders the resource's desired state with all feature mutations
+	// applied, leaving the resource's internal state untouched. Suspension
+	// mutations are not applied; the preview reflects content state only.
+	Preview() (client.Object, error)
+}

--- a/pkg/component/concepts/previewable_test.go
+++ b/pkg/component/concepts/previewable_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -18,10 +19,6 @@ var _ concepts.Previewable = stubPreviewable{}
 func TestPreviewableConformance(t *testing.T) {
 	var p concepts.Previewable = stubPreviewable{obj: &appsv1.Deployment{}}
 	obj, err := p.Preview()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if obj == nil {
-		t.Fatal("expected non-nil object")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, obj)
 }

--- a/pkg/component/concepts/previewable_test.go
+++ b/pkg/component/concepts/previewable_test.go
@@ -1,0 +1,27 @@
+package concepts_test
+
+import (
+	"testing"
+
+	"github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type stubPreviewable struct{ obj client.Object }
+
+func (s stubPreviewable) Preview() (client.Object, error) { return s.obj, nil }
+
+// Compile-time assertion that the interface shape is what we expect.
+var _ concepts.Previewable = stubPreviewable{}
+
+func TestPreviewableConformance(t *testing.T) {
+	var p concepts.Previewable = stubPreviewable{obj: &appsv1.Deployment{}}
+	obj, err := p.Preview()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj == nil {
+		t.Fatal("expected non-nil object")
+	}
+}

--- a/pkg/component/zz_mock_resource_test.go
+++ b/pkg/component/zz_mock_resource_test.go
@@ -172,3 +172,18 @@ func (m *MockObservationRecorderResource) RecordObservation(observed client.Obje
 	args := m.Called(observed)
 	return args.Error(0)
 }
+
+// MockPreviewableResource is a MockResource that also implements
+// concepts.Previewable, for exercising Component.Preview.
+type MockPreviewableResource struct {
+	MockResource
+}
+
+func (m *MockPreviewableResource) Preview() (client.Object, error) {
+	args := m.Called()
+	obj := args.Get(0)
+	if obj == nil {
+		return nil, args.Error(1)
+	}
+	return obj.(client.Object), args.Error(1)
+}

--- a/pkg/generic/resource_base.go
+++ b/pkg/generic/resource_base.go
@@ -80,6 +80,16 @@ func (r *BaseResource[T, M]) PreviewObject() (T, error) {
 	)
 }
 
+// Preview renders the desired object as a client.Object with feature mutations
+// applied, without modifying the resource's internal state. It wraps
+// PreviewObject so resources can be previewed polymorphically through the
+// component's Previewable capability.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+func (r *BaseResource[T, M]) Preview() (client.Object, error) {
+	return r.PreviewObject()
+}
+
 // ExtractData runs all registered data extractors against a deep copy of the reconciled object.
 //
 // For managed resources the reconciled object is the desired state produced by Mutate.

--- a/pkg/generic/resource_base_test.go
+++ b/pkg/generic/resource_base_test.go
@@ -34,3 +34,43 @@ func TestBaseResourcePreviewReturnsClientObject(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "web", baseline.(*appsv1.Deployment).Name)
 }
+
+// TestBaseResourcePreviewDoesNotMutateInternalState verifies that Preview() applies
+// registered mutations to the returned object without modifying the resource's
+// internal DesiredObject.
+func TestBaseResourcePreviewDoesNotMutateInternalState(t *testing.T) {
+	base := &BaseResource[*appsv1.Deployment, *mockMutator]{
+		DesiredObject: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			// No labels on the baseline.
+		},
+		IdentityFunc: func(d *appsv1.Deployment) string { return d.Name },
+		NewMutator:   func(d *appsv1.Deployment) *mockMutator { return &mockMutator{deployment: d} },
+		Mutations: []Mutation[*mockMutator]{
+			mockMutation(func(m *mockMutator) error {
+				if m.deployment.Labels == nil {
+					m.deployment.Labels = map[string]string{}
+				}
+				m.deployment.Labels["mutated"] = "true"
+				return nil
+			}),
+		},
+	}
+
+	obj, err := base.Preview()
+	require.NoError(t, err)
+
+	dep, ok := obj.(*appsv1.Deployment)
+	require.True(t, ok)
+
+	// The returned object must have the mutation applied.
+	assert.Equal(t, "true", dep.Labels["mutated"], "mutation must be present on the previewed object")
+
+	// The internal DesiredObject must be unchanged.
+	assert.Empty(t, base.DesiredObject.Labels, "Preview must not modify internal DesiredObject")
+
+	// Object() deep-copies DesiredObject; the copy must also be clean.
+	baseline, err := base.Object()
+	require.NoError(t, err)
+	assert.Empty(t, baseline.(*appsv1.Deployment).Labels, "Object() must reflect unmodified DesiredObject")
+}

--- a/pkg/generic/resource_base_test.go
+++ b/pkg/generic/resource_base_test.go
@@ -1,0 +1,36 @@
+package generic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestBaseResourcePreviewReturnsClientObject(t *testing.T) {
+	base := &BaseResource[*appsv1.Deployment, *mockMutator]{
+		DesiredObject: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](2)},
+		},
+		IdentityFunc: func(d *appsv1.Deployment) string { return d.Name },
+		NewMutator:   func(d *appsv1.Deployment) *mockMutator { return &mockMutator{deployment: d} },
+	}
+
+	var obj client.Object
+	obj, err := base.Preview()
+	require.NoError(t, err)
+
+	dep, ok := obj.(*appsv1.Deployment)
+	require.True(t, ok)
+	assert.Equal(t, "web", dep.Name)
+
+	// Preview must not mutate internal state: Object() still returns the baseline.
+	baseline, err := base.Object()
+	require.NoError(t, err)
+	assert.Equal(t, "web", baseline.(*appsv1.Deployment).Name)
+}

--- a/pkg/primitives/clusterrole/resource.go
+++ b/pkg/primitives/clusterrole/resource.go
@@ -72,14 +72,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the ClusterRole as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*rbacv1.ClusterRole, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the ClusterRole as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/clusterrole/resource.go
+++ b/pkg/primitives/clusterrole/resource.go
@@ -79,3 +79,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*rbacv1.ClusterRole, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the ClusterRole as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/clusterrolebinding/resource.go
+++ b/pkg/primitives/clusterrolebinding/resource.go
@@ -72,14 +72,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the ClusterRoleBinding as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*rbacv1.ClusterRoleBinding, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the ClusterRoleBinding as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/clusterrolebinding/resource.go
+++ b/pkg/primitives/clusterrolebinding/resource.go
@@ -79,3 +79,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*rbacv1.ClusterRoleBinding, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the ClusterRoleBinding as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/configmap/resource.go
+++ b/pkg/primitives/configmap/resource.go
@@ -77,3 +77,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*corev1.ConfigMap, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the ConfigMap as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/configmap/resource.go
+++ b/pkg/primitives/configmap/resource.go
@@ -70,14 +70,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the ConfigMap as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*corev1.ConfigMap, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the ConfigMap as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/cronjob/resource.go
+++ b/pkg/primitives/cronjob/resource.go
@@ -114,3 +114,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*batchv1.CronJob, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the CronJob as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/cronjob/resource.go
+++ b/pkg/primitives/cronjob/resource.go
@@ -107,14 +107,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the CronJob as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*batchv1.CronJob, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the CronJob as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/daemonset/resource.go
+++ b/pkg/primitives/daemonset/resource.go
@@ -145,3 +145,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*appsv1.DaemonSet, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the DaemonSet as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/daemonset/resource.go
+++ b/pkg/primitives/daemonset/resource.go
@@ -138,14 +138,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the DaemonSet as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*appsv1.DaemonSet, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the DaemonSet as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/deployment/preview_test.go
+++ b/pkg/primitives/deployment/preview_test.go
@@ -1,0 +1,8 @@
+package deployment
+
+import (
+	"github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+)
+
+// Compile-time assertion that the deployment Resource satisfies Previewable.
+var _ concepts.Previewable = (*Resource)(nil)

--- a/pkg/primitives/deployment/resource.go
+++ b/pkg/primitives/deployment/resource.go
@@ -161,3 +161,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*appsv1.Deployment, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the Deployment as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/deployment/resource.go
+++ b/pkg/primitives/deployment/resource.go
@@ -154,14 +154,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the Deployment as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*appsv1.Deployment, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the Deployment as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/hpa/resource.go
+++ b/pkg/primitives/hpa/resource.go
@@ -111,14 +111,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the HorizontalPodAutoscaler as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*autoscalingv2.HorizontalPodAutoscaler, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the HorizontalPodAutoscaler as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/hpa/resource.go
+++ b/pkg/primitives/hpa/resource.go
@@ -118,3 +118,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*autoscalingv2.HorizontalPodAutoscaler, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the HorizontalPodAutoscaler as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/ingress/resource.go
+++ b/pkg/primitives/ingress/resource.go
@@ -132,3 +132,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*networkingv1.Ingress, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the Ingress as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/ingress/resource.go
+++ b/pkg/primitives/ingress/resource.go
@@ -125,14 +125,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the Ingress as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*networkingv1.Ingress, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the Ingress as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/job/resource.go
+++ b/pkg/primitives/job/resource.go
@@ -138,14 +138,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the Job as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*batchv1.Job, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the Job as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/job/resource.go
+++ b/pkg/primitives/job/resource.go
@@ -145,3 +145,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*batchv1.Job, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the Job as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/networkpolicy/resource.go
+++ b/pkg/primitives/networkpolicy/resource.go
@@ -79,3 +79,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*networkingv1.NetworkPolicy, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the NetworkPolicy as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/networkpolicy/resource.go
+++ b/pkg/primitives/networkpolicy/resource.go
@@ -72,14 +72,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the NetworkPolicy as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*networkingv1.NetworkPolicy, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the NetworkPolicy as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/pdb/resource.go
+++ b/pkg/primitives/pdb/resource.go
@@ -72,14 +72,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the PodDisruptionBudget as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*policyv1.PodDisruptionBudget, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the PodDisruptionBudget as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/pdb/resource.go
+++ b/pkg/primitives/pdb/resource.go
@@ -79,3 +79,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*policyv1.PodDisruptionBudget, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the PodDisruptionBudget as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/pod/resource.go
+++ b/pkg/primitives/pod/resource.go
@@ -145,3 +145,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*corev1.Pod, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the Pod as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/pod/resource.go
+++ b/pkg/primitives/pod/resource.go
@@ -138,14 +138,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the Pod as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*corev1.Pod, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the Pod as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/pv/resource.go
+++ b/pkg/primitives/pv/resource.go
@@ -89,14 +89,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the PersistentVolume as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*corev1.PersistentVolume, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the PersistentVolume as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/pv/resource.go
+++ b/pkg/primitives/pv/resource.go
@@ -96,3 +96,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*corev1.PersistentVolume, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the PersistentVolume as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/pvc/resource.go
+++ b/pkg/primitives/pvc/resource.go
@@ -119,14 +119,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the PersistentVolumeClaim as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*corev1.PersistentVolumeClaim, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the PersistentVolumeClaim as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/pvc/resource.go
+++ b/pkg/primitives/pvc/resource.go
@@ -126,3 +126,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*corev1.PersistentVolumeClaim, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the PersistentVolumeClaim as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/replicaset/resource.go
+++ b/pkg/primitives/replicaset/resource.go
@@ -132,14 +132,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the ReplicaSet as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*appsv1.ReplicaSet, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the ReplicaSet as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/replicaset/resource.go
+++ b/pkg/primitives/replicaset/resource.go
@@ -139,3 +139,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*appsv1.ReplicaSet, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the ReplicaSet as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/role/resource.go
+++ b/pkg/primitives/role/resource.go
@@ -71,14 +71,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the Role as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*rbacv1.Role, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the Role as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/role/resource.go
+++ b/pkg/primitives/role/resource.go
@@ -78,3 +78,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*rbacv1.Role, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the Role as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/rolebinding/resource.go
+++ b/pkg/primitives/rolebinding/resource.go
@@ -67,14 +67,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the RoleBinding as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*rbacv1.RoleBinding, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the RoleBinding as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/rolebinding/resource.go
+++ b/pkg/primitives/rolebinding/resource.go
@@ -74,3 +74,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*rbacv1.RoleBinding, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the RoleBinding as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/secret/resource.go
+++ b/pkg/primitives/secret/resource.go
@@ -77,3 +77,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*corev1.Secret, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the Secret as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/secret/resource.go
+++ b/pkg/primitives/secret/resource.go
@@ -70,14 +70,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the Secret as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*corev1.Secret, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the Secret as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/service/resource.go
+++ b/pkg/primitives/service/resource.go
@@ -159,3 +159,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*corev1.Service, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the Service as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/service/resource.go
+++ b/pkg/primitives/service/resource.go
@@ -152,14 +152,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the Service as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*corev1.Service, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the Service as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/serviceaccount/resource.go
+++ b/pkg/primitives/serviceaccount/resource.go
@@ -70,14 +70,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the ServiceAccount as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*corev1.ServiceAccount, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the ServiceAccount as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/serviceaccount/resource.go
+++ b/pkg/primitives/serviceaccount/resource.go
@@ -77,3 +77,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*corev1.ServiceAccount, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the ServiceAccount as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/statefulset/resource.go
+++ b/pkg/primitives/statefulset/resource.go
@@ -135,14 +135,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the StatefulSet as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*appsv1.StatefulSet, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the StatefulSet as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/statefulset/resource.go
+++ b/pkg/primitives/statefulset/resource.go
@@ -142,3 +142,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*appsv1.StatefulSet, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the StatefulSet as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/unstructured/integration/resource.go
+++ b/pkg/primitives/unstructured/integration/resource.go
@@ -95,14 +95,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the object as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*uns.Unstructured, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the object as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/unstructured/integration/resource.go
+++ b/pkg/primitives/unstructured/integration/resource.go
@@ -102,3 +102,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*uns.Unstructured, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the object as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/unstructured/static/resource.go
+++ b/pkg/primitives/unstructured/static/resource.go
@@ -64,14 +64,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the object as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*uns.Unstructured, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the object as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/unstructured/static/resource.go
+++ b/pkg/primitives/unstructured/static/resource.go
@@ -71,3 +71,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*uns.Unstructured, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the object as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/unstructured/task/resource.go
+++ b/pkg/primitives/unstructured/task/resource.go
@@ -87,14 +87,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the object as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*uns.Unstructured, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the object as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/unstructured/task/resource.go
+++ b/pkg/primitives/unstructured/task/resource.go
@@ -94,3 +94,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*uns.Unstructured, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the object as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/primitives/unstructured/workload/resource.go
+++ b/pkg/primitives/unstructured/workload/resource.go
@@ -95,14 +95,6 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 	return r.base.GuardStatus()
 }
 
-// PreviewObject returns the object as it would appear after feature mutations
-// have been applied, without modifying the resource's internal state.
-//
-// Suspension mutations are not applied; the preview reflects content state only.
-func (r *Resource) PreviewObject() (*uns.Unstructured, error) {
-	return r.base.PreviewObject()
-}
-
 // Preview renders the object as a client.Object with feature mutations applied,
 // without modifying the resource's internal state. It satisfies the component's
 // Previewable capability so the component can assemble a cluster-free preview.

--- a/pkg/primitives/unstructured/workload/resource.go
+++ b/pkg/primitives/unstructured/workload/resource.go
@@ -102,3 +102,13 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) PreviewObject() (*uns.Unstructured, error) {
 	return r.base.PreviewObject()
 }
+
+// Preview renders the object as a client.Object with feature mutations applied,
+// without modifying the resource's internal state. It satisfies the component's
+// Previewable capability so the component can assemble a cluster-free preview.
+//
+// Suspension mutations are not applied; the preview reflects content state only.
+// Callers needing the concrete type can type-assert the returned object.
+func (r *Resource) Preview() (client.Object, error) {
+	return r.base.Preview()
+}

--- a/pkg/testing/golden/golden.go
+++ b/pkg/testing/golden/golden.go
@@ -3,6 +3,7 @@
 package golden
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,10 +17,17 @@ import (
 )
 
 // Previewer is satisfied by any resource primitive that can render its
-// post-mutation state. All built-in primitives implement this through
-// [generic.BaseResource].
-type Previewer[T client.Object] interface {
-	PreviewObject() (T, error)
+// post-mutation state as a client.Object. All built-in primitives implement
+// this through generic.BaseResource.
+type Previewer interface {
+	Preview() (client.Object, error)
+}
+
+// ComponentPreviewer is satisfied by a built component that can render the
+// desired state of all the resources it would apply. The component package's
+// *Component implements this through its Preview method.
+type ComponentPreviewer interface {
+	Preview() ([]client.Object, error)
 }
 
 type config struct {
@@ -66,23 +74,23 @@ func (e *MismatchError) Error() string {
 	return fmt.Sprintf("golden file mismatch: %s\n\n%s", e.Path, e.Diff)
 }
 
-// CompareYAML calls PreviewObject on p, serializes the result as YAML, and
-// compares it against the golden file at path. Returns a [*MismatchError] if
-// they differ, or nil if they match.
+// CompareYAML calls Preview on p, serializes the result as YAML, and compares
+// it against the golden file at path. Returns a [*MismatchError] if they
+// differ, or nil if they match.
 //
 // When [Update] is enabled, the golden file is written (creating intermediate
 // directories as needed) and comparison is skipped.
 //
 // Returns an error if the golden file does not exist and Update is not enabled.
-func CompareYAML[T client.Object](path string, p Previewer[T], opts ...Option) error {
+func CompareYAML(path string, p Previewer, opts ...Option) error {
 	var cfg config
 	for _, o := range opts {
 		o(&cfg)
 	}
 
-	obj, err := p.PreviewObject()
+	obj, err := p.Preview()
 	if err != nil {
-		return fmt.Errorf("PreviewObject failed: %w", err)
+		return fmt.Errorf("Preview failed: %w", err)
 	}
 
 	actual, err := serializeObject(obj, cfg.scheme)
@@ -90,7 +98,60 @@ func CompareYAML[T client.Object](path string, p Previewer[T], opts ...Option) e
 		return fmt.Errorf("failed to serialize object to YAML: %w", err)
 	}
 
-	if cfg.update {
+	return compareOrUpdate(path, actual, cfg.update)
+}
+
+// AssertYAML is a test helper that calls [CompareYAML] and fails the test if
+// the result does not match the golden file. See [CompareYAML] for details.
+func AssertYAML(t *testing.T, path string, p Previewer, opts ...Option) {
+	t.Helper()
+	require.NoError(t, CompareYAML(path, p, opts...))
+}
+
+// CompareComponentYAML calls Preview on c, serializes every rendered object
+// into a single multi-document YAML stream (--- separated, in the order
+// Preview returns them), and compares it against the golden file at path.
+// Returns a [*MismatchError] if they differ, or nil if they match.
+//
+// When [Update] is enabled, the golden file is written and comparison is
+// skipped. [WithScheme] is applied to each object as in [CompareYAML]. An
+// empty preview produces empty output.
+func CompareComponentYAML(path string, c ComponentPreviewer, opts ...Option) error {
+	var cfg config
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	objs, err := c.Preview()
+	if err != nil {
+		return fmt.Errorf("Preview failed: %w", err)
+	}
+
+	docs := make([][]byte, 0, len(objs))
+	for i, obj := range objs {
+		doc, err := serializeObject(obj, cfg.scheme)
+		if err != nil {
+			return fmt.Errorf("failed to serialize object %d to YAML: %w", i, err)
+		}
+		docs = append(docs, doc)
+	}
+
+	actual := bytes.Join(docs, []byte("---\n"))
+
+	return compareOrUpdate(path, actual, cfg.update)
+}
+
+// AssertComponentYAML is a test helper that calls [CompareComponentYAML] and
+// fails the test if the result does not match the golden file.
+func AssertComponentYAML(t *testing.T, path string, c ComponentPreviewer, opts ...Option) {
+	t.Helper()
+	require.NoError(t, CompareComponentYAML(path, c, opts...))
+}
+
+// compareOrUpdate writes actual to path when update is set, otherwise compares
+// actual against the existing golden file at path.
+func compareOrUpdate(path string, actual []byte, update bool) error {
+	if update {
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			return fmt.Errorf("failed to create golden file directory: %w", err)
 		}
@@ -109,20 +170,9 @@ func CompareYAML[T client.Object](path string, p Previewer[T], opts ...Option) e
 	}
 
 	if string(expected) != string(actual) {
-		return &MismatchError{
-			Path: path,
-			Diff: formatDiff(string(expected), string(actual)),
-		}
+		return &MismatchError{Path: path, Diff: formatDiff(string(expected), string(actual))}
 	}
-
 	return nil
-}
-
-// AssertYAML is a test helper that calls [CompareYAML] and fails the test if
-// the result does not match the golden file. See [CompareYAML] for details.
-func AssertYAML[T client.Object](t *testing.T, path string, p Previewer[T], opts ...Option) {
-	t.Helper()
-	require.NoError(t, CompareYAML(path, p, opts...))
 }
 
 // serializeObject marshals a client.Object to YAML, removing zero-value noise

--- a/pkg/testing/golden/golden_test.go
+++ b/pkg/testing/golden/golden_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // fakePreviewer implements Previewer for testing without pulling in the full
@@ -22,8 +24,11 @@ type fakePreviewer struct {
 	err error
 }
 
-func (f *fakePreviewer) PreviewObject() (*appsv1.Deployment, error) {
-	return f.obj, f.err
+func (f *fakePreviewer) Preview() (client.Object, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.obj, nil
 }
 
 func testDeployment() *appsv1.Deployment {
@@ -132,13 +137,13 @@ func TestCompareYAML(t *testing.T) {
 		assert.Contains(t, err.Error(), "does not exist")
 	})
 
-	t.Run("should error when PreviewObject fails", func(t *testing.T) {
+	t.Run("should error when Preview fails", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "deployment.yaml")
 
 		err := CompareYAML(path, &fakePreviewer{err: assert.AnError})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "PreviewObject failed")
+		assert.Contains(t, err.Error(), "Preview failed")
 	})
 }
 
@@ -154,6 +159,56 @@ func TestAssertYAML(t *testing.T) {
 
 		// Now assert against it.
 		AssertYAML(t, path, p)
+	})
+}
+
+type fakeComponentPreviewer struct {
+	objs []client.Object
+	err  error
+}
+
+func (f *fakeComponentPreviewer) Preview() ([]client.Object, error) {
+	return f.objs, f.err
+}
+
+func TestCompareComponentYAML(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"},
+		Data:       map[string]string{"k": "v"},
+	}
+	dep := testDeployment()
+
+	t.Run("writes and matches a multi-document golden", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "component.yaml")
+		c := &fakeComponentPreviewer{objs: []client.Object{dep, cm}}
+		require.NoError(t, CompareComponentYAML(path, c, Update(true)))
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "\n---\n") // documents are separated
+		assert.True(t, strings.Index(string(data), "Deployment") < strings.Index(string(data), "ConfigMap"),
+			"documents must preserve Preview() order")
+
+		require.NoError(t, CompareComponentYAML(path, c))
+	})
+
+	t.Run("returns MismatchError on difference", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "component.yaml")
+		require.NoError(t, CompareComponentYAML(path, &fakeComponentPreviewer{objs: []client.Object{dep}}, Update(true)))
+
+		err := CompareComponentYAML(path, &fakeComponentPreviewer{objs: []client.Object{cm}})
+		require.Error(t, err)
+		var mismatch *MismatchError
+		assert.ErrorAs(t, err, &mismatch)
+	})
+
+	t.Run("empty preview writes empty golden", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.yaml")
+		require.NoError(t, CompareComponentYAML(path, &fakeComponentPreviewer{}, Update(true)))
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Empty(t, strings.TrimSpace(string(data)))
 	})
 }
 


### PR DESCRIPTION
## Summary

Closes #121.

Adds a public, cluster-free way to render a built `Component`'s assembled desired-state resources, so consumers can snapshot-test the full resource set the controller actually builds (baseline + mutations + registration order) without a fake client or a reconcile.

- New capability interface `concepts.Previewable { Preview() (client.Object, error) }`, implemented by `generic.BaseResource` (wrapping the existing no-side-effect `PreviewObject()` engine).
- `Component.Preview() ([]client.Object, error)` renders managed reconcile resources in registration order, with no cluster IO. Read-only resources (fetched, not applied) and delete resources (removal markers) are excluded. Errors if a managed resource is not previewable, renders a nil object, or fails to render. `Reconcile` remains the only IO path.
- `Component.Resource(identity string) (Resource, bool)` looks up any registered resource by its `Identity()`.
- `pkg/testing/golden` gains whole-component helpers `CompareComponentYAML` / `AssertComponentYAML` that serialize a component's preview into one multi-document (`---`-separated) golden file.

### Breaking changes (pre-1.0)

- Each primitive's typed `PreviewObject() (*Concrete, error)` is replaced by a single `Preview() (client.Object, error)`. Callers needing the concrete type assert on the returned `client.Object`. The typed engine `generic.BaseResource.PreviewObject()` is retained for internal/custom-resource use.
- The `golden` single-resource API is now non-generic: `Previewer`, `CompareYAML`, `AssertYAML` use `Preview()` instead of the generic `PreviewObject[T]`. Existing `golden.AssertYAML(t, path, res, ...)` call sites are unchanged.

Docs updated in `docs/component.md` and `docs/guidelines.md`.

## Test Plan

- [x] `make all` (lint, format, unit tests) passes
- [x] `go test ./...` — 42 packages, 0 failures
- [x] `make build-examples` builds; example tests pass
- [x] New tests cover: registration order, read-only/delete exclusion, not-previewable error, render-error wrapping, nil-object guard, `BaseResource.Preview` no-side-effect under a real mutation, golden multi-document match/mismatch/update/empty
- No e2e needed: pure in-memory desired-state rendering with no cluster IO

🤖 Generated with [Claude Code](https://claude.com/claude-code)