### PR TITLE
Expose registered mutations and firing-set; export golden serializer

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -180,6 +180,62 @@ func (c *Component) Preview() ([]client.Object, error) {
 	return objs, nil
 }
 
+// RegisteredMutations returns the deduplicated union of the registered mutation
+// Names across the component's managed (non read-only) resources, in resource
+// registration order. Resources that do not implement concepts.MutationInspector
+// contribute nothing. It satisfies concepts.MutationInspector.
+func (c *Component) RegisteredMutations() []string {
+	seen := make(map[string]struct{})
+	names := make([]string, 0)
+	for _, entry := range c.reconcileResources {
+		if entry.Options.ReadOnly {
+			continue
+		}
+		inspector, ok := entry.Resource.(concepts.MutationInspector)
+		if !ok {
+			continue
+		}
+		for _, name := range inspector.RegisteredMutations() {
+			if _, dup := seen[name]; dup {
+				continue
+			}
+			seen[name] = struct{}{}
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// FiringSet returns the deduplicated union of the firing-set Names across the
+// component's managed (non read-only) resources, in resource registration order.
+// It returns an error if any managed resource's FiringSet evaluation fails. It
+// satisfies concepts.MutationInspector.
+func (c *Component) FiringSet() ([]string, error) {
+	seen := make(map[string]struct{})
+	firing := make([]string, 0)
+	for _, entry := range c.reconcileResources {
+		if entry.Options.ReadOnly {
+			continue
+		}
+		inspector, ok := entry.Resource.(concepts.MutationInspector)
+		if !ok {
+			continue
+		}
+		names, err := inspector.FiringSet()
+		if err != nil {
+			return nil, fmt.Errorf("firing set for resource %q: %w", entry.Resource.Identity(), err)
+		}
+		for _, name := range names {
+			if _, dup := seen[name]; dup {
+				continue
+			}
+			seen[name] = struct{}{}
+			firing = append(firing, name)
+		}
+	}
+	return firing, nil
+}
+
 // Resource returns the registered resource with the given Identity() and true,
 // or nil and false if no such resource is registered. The lookup covers every
 // registered resource, including read-only and delete resources.

--- a/pkg/component/component_inspect_test.go
+++ b/pkg/component/component_inspect_test.go
@@ -1,0 +1,83 @@
+package component
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// inspectableResource is a minimal Resource that also implements
+// concepts.MutationInspector, for exercising the component's aggregation.
+type inspectableResource struct {
+	identity   string
+	registered []string
+	firing     []string
+	firingErr  error
+}
+
+func (r *inspectableResource) Identity() string { return r.identity }
+
+func (r *inspectableResource) Object() (client.Object, error) {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: r.identity}}, nil
+}
+
+func (r *inspectableResource) Mutate(_ client.Object) error  { return nil }
+func (r *inspectableResource) RegisteredMutations() []string { return r.registered }
+func (r *inspectableResource) FiringSet() ([]string, error)  { return r.firing, r.firingErr }
+
+func buildInspectComponent(t *testing.T, regs ...func(*Builder)) *Component {
+	t.Helper()
+	b := NewComponentBuilder().WithName("test").WithConditionType("Ready")
+	for _, reg := range regs {
+		reg(b)
+	}
+	c, err := b.Build()
+	require.NoError(t, err)
+	return c
+}
+
+func TestComponentRegisteredMutationsUnion(t *testing.T) {
+	res1 := &inspectableResource{identity: "res1", registered: []string{"A", "B"}}
+	res2 := &inspectableResource{identity: "res2", registered: []string{"B", "C"}}
+	res3 := &inspectableResource{identity: "res3", registered: []string{"X"}}
+
+	c := buildInspectComponent(t,
+		func(b *Builder) { b.WithResource(res1) },
+		func(b *Builder) { b.WithResource(res2) },
+		func(b *Builder) { b.WithResource(res3, ReadOnly()) },
+	)
+
+	// Read-only res3 is excluded; union preserves registration order.
+	assert.Equal(t, []string{"A", "B", "C"}, c.RegisteredMutations())
+}
+
+func TestComponentFiringSetUnion(t *testing.T) {
+	res1 := &inspectableResource{identity: "res1", registered: []string{"A"}, firing: []string{"A"}}
+	res2 := &inspectableResource{identity: "res2", registered: []string{"C"}, firing: []string{"C"}}
+	res3 := &inspectableResource{identity: "res3", registered: []string{"X"}, firing: []string{"X"}}
+
+	c := buildInspectComponent(t,
+		func(b *Builder) { b.WithResource(res1) },
+		func(b *Builder) { b.WithResource(res2) },
+		func(b *Builder) { b.WithResource(res3, ReadOnly()) },
+	)
+
+	firing, err := c.FiringSet()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"A", "C"}, firing)
+}
+
+func TestComponentFiringSetPropagatesError(t *testing.T) {
+	res := &inspectableResource{identity: "res", registered: []string{"A"}, firingErr: errors.New("boom")}
+
+	c := buildInspectComponent(t, func(b *Builder) { b.WithResource(res) })
+
+	_, err := c.FiringSet()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "res")
+}

--- a/pkg/component/concepts/mutation_inspector.go
+++ b/pkg/component/concepts/mutation_inspector.go
@@ -1,0 +1,20 @@
+package concepts
+
+// MutationInspector surfaces, read-only, the mutations registered on a built
+// resource or component and which of them fire at the version it was built at.
+//
+// All built-in primitives satisfy this through generic.BaseResource, and the
+// component aggregates its managed resources. It is an inert capability: nothing
+// in the reconcile path calls it, so importing it costs nothing at runtime.
+type MutationInspector interface {
+	// RegisteredMutations returns the deduplicated Names of every mutation
+	// registered on the unit, independent of the version it was built at.
+	RegisteredMutations() []string
+
+	// FiringSet returns the Names of registered mutations whose gate is enabled
+	// for the version the unit was built at. A mutation with a nil gate fires
+	// unconditionally and is always included. It returns an error if any gate's
+	// Enabled evaluation fails, since a swallowed gate error would silently
+	// misclassify a version regime.
+	FiringSet() ([]string, error)
+}

--- a/pkg/generic/resource_base.go
+++ b/pkg/generic/resource_base.go
@@ -32,6 +32,44 @@ func (r *BaseResource[T, M]) Identity() string {
 	return r.IdentityFunc(r.DesiredObject)
 }
 
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the resource, in registration order, independent of the version it was built
+// at. It satisfies concepts.MutationInspector.
+func (r *BaseResource[T, M]) RegisteredMutations() []string {
+	seen := make(map[string]struct{}, len(r.Mutations))
+	names := make([]string, 0, len(r.Mutations))
+	for _, m := range r.Mutations {
+		if _, ok := seen[m.Name]; ok {
+			continue
+		}
+		seen[m.Name] = struct{}{}
+		names = append(names, m.Name)
+	}
+	return names
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the resource was built at, in registration order. A mutation with a nil
+// Feature fires unconditionally. It returns an error if any gate's Enabled
+// evaluation fails. It satisfies concepts.MutationInspector.
+func (r *BaseResource[T, M]) FiringSet() ([]string, error) {
+	firing := make([]string, 0, len(r.Mutations))
+	for _, m := range r.Mutations {
+		if m.Feature == nil {
+			firing = append(firing, m.Name)
+			continue
+		}
+		enabled, err := m.Feature.Enabled()
+		if err != nil {
+			return nil, fmt.Errorf("evaluating gate for mutation %q: %w", m.Name, err)
+		}
+		if enabled {
+			firing = append(firing, m.Name)
+		}
+	}
+	return firing, nil
+}
+
 // Object returns a deep copy of the desired object.
 func (r *BaseResource[T, M]) Object() (client.Object, error) {
 	obj, ok := r.DesiredObject.DeepCopyObject().(client.Object)

--- a/pkg/generic/resource_base_inspect_test.go
+++ b/pkg/generic/resource_base_inspect_test.go
@@ -44,7 +44,7 @@ func TestBaseResourceRegisteredMutations(t *testing.T) {
 
 func TestBaseResourceFiringSet(t *testing.T) {
 	base := newBase(
-		generic.Mutation[noopMutator]{Name: "Always"},                                  // nil gate -> fires
+		generic.Mutation[noopMutator]{Name: "Always"},                                   // nil gate -> fires
 		generic.Mutation[noopMutator]{Name: "On", Feature: staticGate{enabled: true}},   // fires
 		generic.Mutation[noopMutator]{Name: "Off", Feature: staticGate{enabled: false}}, // does not fire
 	)

--- a/pkg/generic/resource_base_inspect_test.go
+++ b/pkg/generic/resource_base_inspect_test.go
@@ -1,0 +1,63 @@
+package generic_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sourcehawk/operator-component-framework/pkg/generic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// staticGate is a feature.Gate with a fixed outcome for tests.
+type staticGate struct {
+	enabled bool
+	err     error
+}
+
+func (g staticGate) Enabled() (bool, error) { return g.enabled, g.err }
+
+// noopMutator is a minimal generic.FeatureMutator for exercising BaseResource.
+type noopMutator struct{}
+
+func (noopMutator) NextFeature() {}
+func (noopMutator) Apply() error { return nil }
+
+func newBase(mutations ...generic.Mutation[noopMutator]) *generic.BaseResource[*corev1.ConfigMap, noopMutator] {
+	return &generic.BaseResource[*corev1.ConfigMap, noopMutator]{
+		DesiredObject: &corev1.ConfigMap{},
+		NewMutator:    func(*corev1.ConfigMap) noopMutator { return noopMutator{} },
+		IdentityFunc:  func(*corev1.ConfigMap) string { return "cm" },
+		Mutations:     mutations,
+	}
+}
+
+func TestBaseResourceRegisteredMutations(t *testing.T) {
+	base := newBase(
+		generic.Mutation[noopMutator]{Name: "A"},
+		generic.Mutation[noopMutator]{Name: "B"},
+		generic.Mutation[noopMutator]{Name: "A"}, // duplicate
+	)
+	assert.Equal(t, []string{"A", "B"}, base.RegisteredMutations())
+}
+
+func TestBaseResourceFiringSet(t *testing.T) {
+	base := newBase(
+		generic.Mutation[noopMutator]{Name: "Always"},                                  // nil gate -> fires
+		generic.Mutation[noopMutator]{Name: "On", Feature: staticGate{enabled: true}},   // fires
+		generic.Mutation[noopMutator]{Name: "Off", Feature: staticGate{enabled: false}}, // does not fire
+	)
+	firing, err := base.FiringSet()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Always", "On"}, firing)
+}
+
+func TestBaseResourceFiringSetGateError(t *testing.T) {
+	base := newBase(
+		generic.Mutation[noopMutator]{Name: "Bad", Feature: staticGate{err: errors.New("boom")}},
+	)
+	_, err := base.FiringSet()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Bad")
+}

--- a/pkg/primitives/clusterrole/resource.go
+++ b/pkg/primitives/clusterrole/resource.go
@@ -81,3 +81,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the ClusterRole, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the ClusterRole was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/clusterrolebinding/resource.go
+++ b/pkg/primitives/clusterrolebinding/resource.go
@@ -81,3 +81,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the ClusterRoleBinding, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the ClusterRoleBinding was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/configmap/resource.go
+++ b/pkg/primitives/configmap/resource.go
@@ -79,3 +79,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the ConfigMap, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the ConfigMap was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/cronjob/resource.go
+++ b/pkg/primitives/cronjob/resource.go
@@ -116,3 +116,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the CronJob, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the CronJob was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/daemonset/resource.go
+++ b/pkg/primitives/daemonset/resource.go
@@ -147,3 +147,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the DaemonSet, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the DaemonSet was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/deployment/resource.go
+++ b/pkg/primitives/deployment/resource.go
@@ -163,3 +163,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the Deployment, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the Deployment was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/hpa/resource.go
+++ b/pkg/primitives/hpa/resource.go
@@ -120,3 +120,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the HorizontalPodAutoscaler, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the HorizontalPodAutoscaler was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/ingress/resource.go
+++ b/pkg/primitives/ingress/resource.go
@@ -134,3 +134,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the Ingress, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the Ingress was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/job/resource.go
+++ b/pkg/primitives/job/resource.go
@@ -147,3 +147,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the Job, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the Job was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/networkpolicy/resource.go
+++ b/pkg/primitives/networkpolicy/resource.go
@@ -81,3 +81,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the NetworkPolicy, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the NetworkPolicy was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/pdb/resource.go
+++ b/pkg/primitives/pdb/resource.go
@@ -81,3 +81,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the PodDisruptionBudget, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the PodDisruptionBudget was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/pod/resource.go
+++ b/pkg/primitives/pod/resource.go
@@ -147,3 +147,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the Pod, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the Pod was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/pv/resource.go
+++ b/pkg/primitives/pv/resource.go
@@ -98,3 +98,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the PersistentVolume, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the PersistentVolume was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/pvc/resource.go
+++ b/pkg/primitives/pvc/resource.go
@@ -128,3 +128,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the PersistentVolumeClaim, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the PersistentVolumeClaim was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/replicaset/resource.go
+++ b/pkg/primitives/replicaset/resource.go
@@ -141,3 +141,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the ReplicaSet, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the ReplicaSet was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/role/resource.go
+++ b/pkg/primitives/role/resource.go
@@ -80,3 +80,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the Role, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the Role was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/rolebinding/resource.go
+++ b/pkg/primitives/rolebinding/resource.go
@@ -76,3 +76,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the RoleBinding, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the RoleBinding was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/secret/resource.go
+++ b/pkg/primitives/secret/resource.go
@@ -79,3 +79,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the Secret, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the Secret was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/service/resource.go
+++ b/pkg/primitives/service/resource.go
@@ -161,3 +161,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the Service, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the Service was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/serviceaccount/resource.go
+++ b/pkg/primitives/serviceaccount/resource.go
@@ -79,3 +79,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the ServiceAccount, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the ServiceAccount was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/statefulset/resource.go
+++ b/pkg/primitives/statefulset/resource.go
@@ -144,3 +144,19 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the StatefulSet, independent of version. It satisfies
+// concepts.MutationInspector so the resource can be introspected for
+// version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the StatefulSet was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/statefulset/resource_inspect_test.go
+++ b/pkg/primitives/statefulset/resource_inspect_test.go
@@ -1,0 +1,28 @@
+package statefulset
+
+import (
+	"testing"
+
+	"github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestResource_MutationInspector(t *testing.T) {
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sts", Namespace: "test-ns"},
+	}
+	res, err := NewBuilder(sts).
+		WithMutation(Mutation{Name: "Always"}).
+		Build()
+	require.NoError(t, err)
+
+	var insp concepts.MutationInspector = res
+	assert.Equal(t, []string{"Always"}, insp.RegisteredMutations())
+
+	firing, err := insp.FiringSet()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Always"}, firing)
+}

--- a/pkg/primitives/unstructured/integration/resource.go
+++ b/pkg/primitives/unstructured/integration/resource.go
@@ -104,3 +104,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the unstructured object, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the unstructured object was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/unstructured/static/resource.go
+++ b/pkg/primitives/unstructured/static/resource.go
@@ -73,3 +73,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the unstructured object, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the unstructured object was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/unstructured/task/resource.go
+++ b/pkg/primitives/unstructured/task/resource.go
@@ -96,3 +96,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the unstructured object, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the unstructured object was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/primitives/unstructured/workload/resource.go
+++ b/pkg/primitives/unstructured/workload/resource.go
@@ -104,3 +104,18 @@ func (r *Resource) GuardStatus() (concepts.GuardStatusWithReason, error) {
 func (r *Resource) Preview() (client.Object, error) {
 	return r.base.Preview()
 }
+
+// RegisteredMutations returns the deduplicated Names of every mutation registered
+// on the unstructured object, independent of version. It satisfies concepts.MutationInspector
+// so the resource can be introspected for version-matrix golden generation.
+func (r *Resource) RegisteredMutations() []string {
+	return r.base.RegisteredMutations()
+}
+
+// FiringSet returns the Names of registered mutations whose gate is enabled for the
+// version the unstructured object was built at. It satisfies concepts.MutationInspector.
+func (r *Resource) FiringSet() ([]string, error) {
+	return r.base.FiringSet()
+}
+
+var _ concepts.MutationInspector = (*Resource)(nil)

--- a/pkg/testing/golden/golden.go
+++ b/pkg/testing/golden/golden.go
@@ -127,18 +127,34 @@ func CompareComponentYAML(path string, c ComponentPreviewer, opts ...Option) err
 		return fmt.Errorf("Preview failed: %w", err)
 	}
 
+	actual, err := SerializeComponent(objs, cfg.scheme)
+	if err != nil {
+		return fmt.Errorf("failed to serialize component objects to YAML: %w", err)
+	}
+
+	return compareOrUpdate(path, actual, cfg.update)
+}
+
+// Serialize marshals a client.Object to the canonical golden YAML form: TypeMeta
+// resolved (from the object or the scheme), and zero-value noise fields stripped.
+// It is the same serialization CompareYAML uses, exported for tools that generate
+// goldens out of band.
+func Serialize(obj client.Object, scheme *runtime.Scheme) ([]byte, error) {
+	return serializeObject(obj, scheme)
+}
+
+// SerializeComponent marshals multiple objects into a single multi-document YAML
+// stream (--- separated, in the given order), matching CompareComponentYAML.
+func SerializeComponent(objs []client.Object, scheme *runtime.Scheme) ([]byte, error) {
 	docs := make([][]byte, 0, len(objs))
 	for i, obj := range objs {
-		doc, err := serializeObject(obj, cfg.scheme)
+		doc, err := serializeObject(obj, scheme)
 		if err != nil {
-			return fmt.Errorf("failed to serialize object %d to YAML: %w", i, err)
+			return nil, fmt.Errorf("failed to serialize object %d to YAML: %w", i, err)
 		}
 		docs = append(docs, doc)
 	}
-
-	actual := bytes.Join(docs, []byte("---\n"))
-
-	return compareOrUpdate(path, actual, cfg.update)
+	return bytes.Join(docs, []byte("---\n")), nil
 }
 
 // AssertComponentYAML is a test helper that calls [CompareComponentYAML] and

--- a/pkg/testing/golden/serialize_test.go
+++ b/pkg/testing/golden/serialize_test.go
@@ -1,0 +1,58 @@
+package golden
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestSerializeMatchesGoldenPath(t *testing.T) {
+	dep := testDeployment()
+	out, err := Serialize(dep, testScheme())
+	require.NoError(t, err)
+
+	// Byte-identical to what CompareYAML writes through the same serializer.
+	path := filepath.Join(t.TempDir(), "dep.yaml")
+	require.NoError(t, CompareYAML(path, &fakePreviewer{obj: dep}, WithScheme(testScheme()), Update(true)))
+	written, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(written), string(out))
+}
+
+func TestSerializeComponentJoinsDocuments(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"},
+		Data:       map[string]string{"k": "v"},
+	}
+	objs := []client.Object{testDeployment(), cm}
+	out, err := SerializeComponent(objs, testScheme())
+	require.NoError(t, err)
+	assert.Equal(t, 2, strings.Count(string(out), "kind:"))
+	assert.Contains(t, string(out), "---\n")
+}
+
+func TestSerializeComponentMatchesCompareComponentYAML(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"},
+		Data:       map[string]string{"k": "v"},
+	}
+	objs := []client.Object{testDeployment(), cm}
+
+	out, err := SerializeComponent(objs, testScheme())
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "component.yaml")
+	require.NoError(t, CompareComponentYAML(path, &fakeComponentPreviewer{objs: objs}, WithScheme(testScheme()), Update(true)))
+	written, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(written), string(out))
+}


### PR DESCRIPTION
Towards #132

## Description

Adds the read-only framework introspection surface and golden serializer export that the version-matrix golden generator (later sub-PRs) builds on. No reconcile-path behavior changes; every addition is an inert getter or a thin wrapper.

## What changed

- New `concepts.MutationInspector` interface (`pkg/component/concepts/mutation_inspector.go`): `RegisteredMutations() []string` and `FiringSet() ([]string, error)`.
- Implemented on `generic.BaseResource`: iterates its existing `Mutations`. A nil `Feature` fires unconditionally; otherwise `Feature.Enabled()` decides. `RegisteredMutations` dedupes in registration order; `FiringSet` preserves registration order and propagates gate errors wrapped with the mutation name.
- Implemented on `*component.Component` as the deduplicated union across managed (non read-only) resources, mirroring the `Preview` iteration. Read-only resources and resources that do not implement the interface contribute nothing; a managed resource's `FiringSet` error is wrapped with the resource identity and propagated.
- Delegation block plus a `var _ concepts.MutationInspector = (*Resource)(nil)` compile-time assertion on every primitive `Resource` (all 21 single-kind primitives and the 4 unstructured sub-resources: static, task, workload, integration). The assertion makes a missed primitive a build failure.
- Exported `golden.Serialize(obj, scheme)` and `golden.SerializeComponent(objs, scheme)` as thin wrappers over the existing private `serializeObject`. Refactored `CompareComponentYAML` to reuse `SerializeComponent` (DRY); output stays byte-identical.

## New public surface

- `concepts.MutationInspector interface { RegisteredMutations() []string; FiringSet() ([]string, error) }`
- `golden.Serialize(client.Object, *runtime.Scheme) ([]byte, error)`
- `golden.SerializeComponent([]client.Object, *runtime.Scheme) ([]byte, error)`

## Testing

- TDD throughout (failing test first, then minimal implementation) for `BaseResource`, `Component`, the statefulset anchor, and the golden serializer.
- `BaseResource`: dedup, nil-gate-fires, enabled/disabled gates, gate-error propagation.
- `Component`: union of registered mutations and firing-sets, read-only exclusion, error propagation.
- Primitives: statefulset satisfies the interface and reports its firing-set; the `var _` assertions cover the remaining 24 resource types at compile time.
- Golden: `Serialize` is byte-identical to what `CompareYAML` writes; `SerializeComponent` joins multi-document YAML identically to `CompareComponentYAML`; existing golden tests still pass.
- `make all` is green (fmt, lint, test, test-examples, build-examples).