### PR TITLE
Add optional YAML matrix loader for goldengen

### DIFF
--- a/pkg/testing/goldengen/loadmatrix.go
+++ b/pkg/testing/goldengen/loadmatrix.go
@@ -1,0 +1,134 @@
+package goldengen
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+)
+
+// matrixFile is the on-disk shape of a version matrix. It mirrors Config without
+// the Go-only Build and Scheme, which LoadMatrix takes as arguments. The struct
+// tags are JSON because sigs.k8s.io/yaml converts YAML to JSON before unmarshalling.
+type matrixFile struct {
+	Dir      string              `json:"dir"`
+	Versions []string            `json:"versions"`
+	Exclude  []string            `json:"exclude"`
+	Fixtures []matrixFixtureFile `json:"fixtures"`
+}
+
+// matrixFixtureFile is the on-disk shape of one fixture. Exactly one of Spec or
+// SpecFile must be set. Spec is captured as a raw JSON message (sigs.k8s.io/yaml
+// has already converted the inline YAML to JSON by this point) and unmarshalled
+// into the typed spec later, which preserves nested fields cleanly.
+type matrixFixtureFile struct {
+	Name     string          `json:"name"`
+	Spec     json.RawMessage `json:"spec"`
+	SpecFile string          `json:"specFile"`
+	Requires []matrixExpect  `json:"requires"`
+	Forbids  []matrixExpect  `json:"forbids"`
+}
+
+// matrixExpect is the on-disk shape of an Expect. It carries lowercase JSON tags
+// so the YAML keys read naturally (name, for) rather than the Go field names.
+type matrixExpect struct {
+	Name string `json:"name"`
+	For  string `json:"for"`
+}
+
+func (e matrixExpect) toExpect() Expect {
+	return Expect(e)
+}
+
+func toExpects(in []matrixExpect) []Expect {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Expect, 0, len(in))
+	for _, e := range in {
+		out = append(out, e.toExpect())
+	}
+	return out
+}
+
+// LoadMatrix reads a YAML matrix file at path and returns a Config ready to run.
+// The file mirrors Config without its Go-only fields: Build and Scheme are supplied
+// here as arguments. Each fixture's CR comes from either an inline spec or an
+// external specFile (exactly one of the two); the CR is unmarshalled into a fresh
+// T from newSpec. A specFile path is resolved relative to the matrix file's
+// directory. Supplying both spec and specFile, or neither, is a load error. The
+// resulting Config is validated via Config.Validate before it is returned, so
+// invariants such as every Expect.For being a member of versions are enforced.
+func LoadMatrix[T any](
+	path string,
+	newSpec func() T,
+	build func(version string, spec T) (Unit, error),
+	scheme *runtime.Scheme,
+) (Config[T], error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Config[T]{}, fmt.Errorf("read matrix %q: %w", path, err)
+	}
+
+	var mf matrixFile
+	if err := yaml.Unmarshal(raw, &mf); err != nil {
+		return Config[T]{}, fmt.Errorf("parse matrix %q: %w", path, err)
+	}
+
+	baseDir := filepath.Dir(path)
+	cfg := Config[T]{
+		Dir:      mf.Dir,
+		Versions: mf.Versions,
+		Exclude:  mf.Exclude,
+		Scheme:   scheme,
+		Build:    build,
+	}
+
+	for _, ff := range mf.Fixtures {
+		spec, err := loadFixtureSpec(ff, baseDir, newSpec)
+		if err != nil {
+			return Config[T]{}, err
+		}
+		cfg.Fixtures = append(cfg.Fixtures, Fixture[T]{
+			Name:     ff.Name,
+			Spec:     spec,
+			Requires: toExpects(ff.Requires),
+			Forbids:  toExpects(ff.Forbids),
+		})
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return Config[T]{}, err
+	}
+	return cfg, nil
+}
+
+// loadFixtureSpec resolves a fixture's CR into a fresh T. It enforces the
+// exactly-one-of(spec, specFile) invariant and resolves specFile relative to
+// baseDir.
+func loadFixtureSpec[T any](ff matrixFixtureFile, baseDir string, newSpec func() T) (T, error) {
+	var zero T
+	hasInline := len(ff.Spec) > 0
+	hasFile := ff.SpecFile != ""
+	if hasInline == hasFile {
+		return zero, fmt.Errorf("fixture %q must set exactly one of spec or specFile", ff.Name)
+	}
+
+	data := []byte(ff.Spec)
+	if hasFile {
+		b, err := os.ReadFile(filepath.Join(baseDir, ff.SpecFile))
+		if err != nil {
+			return zero, fmt.Errorf("fixture %q specFile %q: %w", ff.Name, ff.SpecFile, err)
+		}
+		data = b
+	}
+
+	spec := newSpec()
+	if err := yaml.Unmarshal(data, spec); err != nil {
+		return zero, fmt.Errorf("fixture %q spec: %w", ff.Name, err)
+	}
+	return spec, nil
+}

--- a/pkg/testing/goldengen/loadmatrix_test.go
+++ b/pkg/testing/goldengen/loadmatrix_test.go
@@ -1,0 +1,91 @@
+package goldengen_test
+
+import (
+	"testing"
+
+	"github.com/sourcehawk/operator-component-framework/pkg/primitives/configmap"
+	"github.com/sourcehawk/operator-component-framework/pkg/testing/goldengen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// newCM returns a fresh empty ConfigMap for LoadMatrix to unmarshal each fixture
+// spec into.
+func newCM() *corev1.ConfigMap { return &corev1.ConfigMap{} }
+
+// cmBuildFn materializes a ConfigMap fixture spec into a Unit at a version. The
+// version does not influence the build here; it exists to satisfy the Build
+// signature and to prove the produced Config is runnable.
+func cmBuildFn(_ string, spec *corev1.ConfigMap) (goldengen.Unit, error) {
+	res, err := configmap.NewBuilder(spec).Build()
+	if err != nil {
+		return nil, err
+	}
+	return goldengen.Resource(res, testScheme()), nil
+}
+
+func TestLoadMatrixInline(t *testing.T) {
+	cfg, err := goldengen.LoadMatrix("testdata/matrix_inline.yaml", newCM, cmBuildFn, testScheme())
+	require.NoError(t, err)
+	require.NoError(t, cfg.Validate())
+
+	assert.Equal(t, "testdata/goldens", cfg.Dir)
+	assert.Equal(t, []string{"1.0.0", "2.0.0"}, cfg.Versions)
+	require.Len(t, cfg.Fixtures, 1)
+
+	f := cfg.Fixtures[0]
+	assert.Equal(t, "default", f.Name)
+	// The inline spec must round-trip into the typed T, including nested fields.
+	require.NotNil(t, f.Spec)
+	assert.Equal(t, "from-inline", f.Spec.Name)
+	assert.Equal(t, "default", f.Spec.Namespace)
+	assert.Equal(t, "value", f.Spec.Data["key"])
+
+	require.Len(t, f.Requires, 1)
+	assert.Equal(t, "A", f.Requires[0].Name)
+	assert.Equal(t, "1.0.0", f.Requires[0].For)
+	require.Len(t, f.Forbids, 1)
+	assert.Equal(t, "B", f.Forbids[0].Name)
+}
+
+func TestLoadMatrixSpecFile(t *testing.T) {
+	cfg, err := goldengen.LoadMatrix("testdata/matrix_specfile.yaml", newCM, cmBuildFn, testScheme())
+	require.NoError(t, err)
+	require.NoError(t, cfg.Validate())
+
+	require.Len(t, cfg.Fixtures, 1)
+	// specFile is resolved relative to the matrix file's directory.
+	assert.Equal(t, "from-file", cfg.Fixtures[0].Spec.Name)
+	assert.Equal(t, "default", cfg.Fixtures[0].Spec.Namespace)
+}
+
+func TestLoadMatrixRunnable(t *testing.T) {
+	cfg, err := goldengen.LoadMatrix("testdata/matrix_inline.yaml", newCM, cmBuildFn, testScheme())
+	require.NoError(t, err)
+
+	// The produced Config must be runnable: Build yields a Unit that renders.
+	unit, err := cfg.Build("1.0.0", cfg.Fixtures[0].Spec)
+	require.NoError(t, err)
+	out, err := unit.RenderYAML()
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "from-inline")
+}
+
+func TestLoadMatrixErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "both spec and specFile set", path: "testdata/matrix_both.yaml"},
+		{name: "neither spec nor specFile set", path: "testdata/matrix_neither.yaml"},
+		{name: "For not in versions", path: "testdata/matrix_badfor.yaml"},
+		{name: "missing matrix file", path: "testdata/does_not_exist.yaml"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := goldengen.LoadMatrix(tc.path, newCM, cmBuildFn, testScheme())
+			require.Error(t, err)
+		})
+	}
+}

--- a/pkg/testing/goldengen/testdata/fixtures/cm.yaml
+++ b/pkg/testing/goldengen/testdata/fixtures/cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: from-file
+  namespace: default
+data:
+  key: value

--- a/pkg/testing/goldengen/testdata/matrix_badfor.yaml
+++ b/pkg/testing/goldengen/testdata/matrix_badfor.yaml
@@ -1,0 +1,13 @@
+dir: testdata/goldens
+versions:
+  - 1.0.0
+fixtures:
+  - name: default
+    spec:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: from-inline
+    requires:
+      - name: A
+        for: 9.9.9

--- a/pkg/testing/goldengen/testdata/matrix_both.yaml
+++ b/pkg/testing/goldengen/testdata/matrix_both.yaml
@@ -1,0 +1,11 @@
+dir: testdata/goldens
+versions:
+  - 1.0.0
+fixtures:
+  - name: default
+    spec:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: from-inline
+    specFile: fixtures/cm.yaml

--- a/pkg/testing/goldengen/testdata/matrix_inline.yaml
+++ b/pkg/testing/goldengen/testdata/matrix_inline.yaml
@@ -1,0 +1,19 @@
+dir: testdata/goldens
+versions:
+  - 1.0.0
+  - 2.0.0
+fixtures:
+  - name: default
+    spec:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: from-inline
+        namespace: default
+      data:
+        key: value
+    requires:
+      - name: A
+        for: 1.0.0
+    forbids:
+      - name: B

--- a/pkg/testing/goldengen/testdata/matrix_neither.yaml
+++ b/pkg/testing/goldengen/testdata/matrix_neither.yaml
@@ -1,0 +1,7 @@
+dir: testdata/goldens
+versions:
+  - 1.0.0
+fixtures:
+  - name: default
+    requires:
+      - name: A

--- a/pkg/testing/goldengen/testdata/matrix_specfile.yaml
+++ b/pkg/testing/goldengen/testdata/matrix_specfile.yaml
@@ -1,0 +1,9 @@
+dir: testdata/goldens
+versions:
+  - 1.0.0
+  - 2.0.0
+fixtures:
+  - name: default
+    specFile: fixtures/cm.yaml
+    requires:
+      - name: A


### PR DESCRIPTION
Towards #135

Adds `LoadMatrix`, an optional YAML-driven entry point for the goldengen version matrix. It reads a matrix file that mirrors `Config` without its Go-only fields and returns a `Config` ready to run, with `Build` and `Scheme` supplied as arguments.

## Behaviour

- Top level mirrors `Config`: `dir`, `versions`, `exclude`, `fixtures`.
- Each fixture sets exactly one of `spec` (inline CR) or `specFile` (path relative to the matrix file). Both-set or neither-set is a load error.
- Each fixture spec is unmarshalled into a fresh typed spec from `newSpec`. The inline `spec` is captured as `json.RawMessage` (sigs.k8s.io/yaml has already converted YAML to JSON), which round-trips nested fields cleanly into the typed spec.
- `requires` / `forbids` carry `name` and optional `for`.
- The assembled `Config` is validated via `Config.Validate` before returning, so invariants such as `for` not being a member of `versions` are enforced.

## Tests

Table-driven coverage for inline load, specFile load with relative resolution, both-set error, neither-set error, `for`-not-in-versions error, missing file error, and that the produced `Config` is runnable end to end (build a unit and render it).

`make all` passes.