### PR TITLE
feat(feature): add NewBooleanGate convenience constructor

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -88,6 +88,17 @@ func NewVersionGate(currentVersion string, versionConstraints []VersionConstrain
 	}
 }
 
+// NewBooleanGate creates a VersionGate that is enabled only when enabled is true.
+//
+// It is shorthand for NewVersionGate("", nil).When(enabled): a gate with no
+// version constraints whose result is driven solely by the boolean. Use it for a
+// mutation or resource toggled by a spec flag rather than an application version.
+// Because it returns a *VersionGate, further conditions can still be composed with
+// When.
+func NewBooleanGate(enabled bool) *VersionGate {
+	return NewVersionGate("", nil).When(enabled)
+}
+
 // When adds a boolean condition that must be true for the gate to be enabled.
 //
 // Calls are additive: all values passed through When must be true for Enabled()

--- a/pkg/feature/feature_test.go
+++ b/pkg/feature/feature_test.go
@@ -163,6 +163,36 @@ func TestVersionGate_WhenChaining(t *testing.T) {
 	assert.False(t, enabled)
 }
 
+func TestNewBooleanGate(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		want    bool
+	}{
+		{name: "enabled", enabled: true, want: true},
+		{name: "disabled", enabled: false, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gate := NewBooleanGate(tt.enabled)
+			enabled, err := gate.Enabled()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, enabled)
+		})
+	}
+}
+
+func TestNewBooleanGate_Chainable(t *testing.T) {
+	// NewBooleanGate returns a *VersionGate, so additional When conditions still
+	// compose: every condition must be true for the gate to be enabled.
+	gate := NewBooleanGate(true).When(false)
+
+	enabled, err := gate.Enabled()
+	assert.NoError(t, err)
+	assert.False(t, enabled)
+}
+
 func TestMutation_ApplyIntent(t *testing.T) {
 	const newValue = "new-value"
 	type testObj struct {


### PR DESCRIPTION
## Description

Adds `feature.NewBooleanGate(enabled bool)`, a convenience constructor for a gate driven purely by a boolean. It is shorthand for `feature.NewVersionGate("", nil).When(enabled)`, the form operators reach for whenever a mutation or resource is toggled by a spec flag rather than an application version. The explicit empty-version spelling is easy to mistype and reads obscurely, so this gives that common case a direct, well-named constructor.

## Changes

- Add `feature.NewBooleanGate(enabled bool) *VersionGate`: a gate with no version constraints whose result is driven solely by the boolean. It returns `*VersionGate`, so additional conditions still compose via `When`.

## Related

Documentation and examples adopt the new constructor separately, on the docs site branch.

## Testing

New table tests cover the enabled and disabled results and confirm that further `When` conditions still compose on the returned gate. `go test ./pkg/feature/...` passes, and `go build ./...`, `make build-examples`, and `golangci-lint run ./pkg/feature/...` (0 issues) are all clean.