### PR TITLE
triagent-proposal: Fix incorrect status name in Priority() godoc comment

### DIFF
--- a/pkg/component/concepts/graceful.go
+++ b/pkg/component/concepts/graceful.go
@@ -15,7 +15,7 @@ const (
 
 // Priority returns the priority of the grace status.
 // Higher values indicate more severe health issues.
-// This is used for status aggregation: "Down" takes precedence over "Degraded", which takes precedence over "Ready".
+// This is used for status aggregation: "Down" takes precedence over "Degraded", which takes precedence over "Healthy".
 func (s GraceStatus) Priority() int {
 	switch s {
 	case GraceStatusHealthy:


### PR DESCRIPTION
## Description
Fixes #150. The `Priority()` godoc on `GraceStatus` described the aggregation precedence chain as ending in `"Ready"`, a status that doesn't exist on the type. Changed it to `"Healthy"` so the comment matches the `GraceStatusHealthy` constant declared a few lines above. Doc-only edit, no behaviour change.

## Changes
- Corrected the precedence-chain comment so it now reads `"Down" takes precedence over "Degraded", which takes precedence over "Healthy".`, aligning all three names with the `GraceStatusDown` / `GraceStatusDegraded` / `GraceStatusHealthy` constants. [1]

## Testing
`go build ./pkg/component/concepts/` succeeds. The change touches only a comment, so there is no behaviour to exercise - the `Priority()` switch already returns `1` for `GraceStatusHealthy`, confirming it is the lowest-severity value the comment now names. [1]

---
🤖 Drafted by triagent-proposal.
