### PR TITLE
triagent-proposal: Add trailing period to grace-period failure message

### DIFF
--- a/pkg/component/converge.go
+++ b/pkg/component/converge.go
@@ -130,7 +130,7 @@ func (c reconcileResults) graceSummary() concepts.GraceStatusWithReason {
 	if !anyGraceful {
 		return concepts.GraceStatusWithReason{
 			Status: concepts.GraceStatusDown,
-			Reason: "Component failed to converge within grace period",
+			Reason: "Component failed to converge within grace period.",
 		}
 	}
 

--- a/pkg/component/converge_test.go
+++ b/pkg/component/converge_test.go
@@ -146,6 +146,7 @@ func TestConvergeResultsGraceSummary(t *testing.T) {
 		require.NoError(t, results.evaluateGrace())
 		summary := results.graceSummary()
 		assert.Equal(t, concepts.GraceStatusDown, summary.Status)
+		assert.Equal(t, "Component failed to converge within grace period.", summary.Reason)
 	})
 
 	t.Run("should aggregate grace status of alive resources", func(t *testing.T) {


### PR DESCRIPTION
## Description
Fixes #152. The `graceSummary` fallback in `pkg/component/converge.go` set its `Reason` to `"Component failed to converge within grace period"` - the only component status message without a trailing period. This adds the period so the string matches the punctuation of every other `.status.conditions[].message` value the framework emits.

## Changes
- Appended a trailing period to the no-alive-resources grace fallback message:
  ```go
  Reason: "Component failed to converge within grace period.",
  ```

## Testing
The existing `TestConvergeResultsGraceSummary/should_return_concepts.GraceStatusDown_if_no_alive_resources` case previously only asserted on `summary.Status`; I added an assertion on `summary.Reason` for the full message. Confirmed it fails against the old string and passes after the fix (`go test ./pkg/component/ -run TestConvergeResultsGraceSummary`). `gofmt` and `go vet` are clean. Note: the package's envtest suite (`TestComponent`) is skipped locally because kubebuilder/etcd binaries aren't installed in this worktree - CI provisions these via `make test`, so that path runs there.

---
🤖 Drafted by triagent-proposal.
