### PR TITLE
test(examples): guard golden.Previewer type assertions

### DIFF
--- a/examples/component-prerequisites/resources/configmap_test.go
+++ b/examples/component-prerequisites/resources/configmap_test.go
@@ -34,6 +34,9 @@ func TestConfigMapShape(t *testing.T) {
 	res, err := resources.NewConfigMapResource(owner)
 	require.NoError(t, err)
 
-	golden.AssertYAML(t, "testdata/configmap.yaml", res.(golden.Previewer),
+	previewer, ok := res.(golden.Previewer)
+	require.True(t, ok)
+
+	golden.AssertYAML(t, "testdata/configmap.yaml", previewer,
 		golden.WithScheme(scheme), golden.Update(*update))
 }

--- a/examples/component-prerequisites/resources/deployment_test.go
+++ b/examples/component-prerequisites/resources/deployment_test.go
@@ -62,7 +62,10 @@ func TestDeploymentShape(t *testing.T) {
 			res, err := resources.NewDeploymentResource(owner)
 			require.NoError(t, err)
 
-			golden.AssertYAML(t, tt.golden, res.(golden.Previewer),
+			previewer, ok := res.(golden.Previewer)
+			require.True(t, ok)
+
+			golden.AssertYAML(t, tt.golden, previewer,
 				golden.WithScheme(scheme), golden.Update(*update))
 		})
 	}

--- a/examples/custom-resource/resources/certificate_test.go
+++ b/examples/custom-resource/resources/certificate_test.go
@@ -49,7 +49,10 @@ func TestCertificateShape(t *testing.T) {
 	res, err := resources.NewCertificateResource(testOwner())
 	require.NoError(t, err)
 
-	golden.AssertYAML(t, "testdata/certificate.yaml", res.(golden.Previewer), golden.Update(*update))
+	previewer, ok := res.(golden.Previewer)
+	require.True(t, ok)
+
+	golden.AssertYAML(t, "testdata/certificate.yaml", previewer, golden.Update(*update))
 }
 
 // TestCertificateBaseShape pins the bare base object before any mutations.

--- a/examples/extraction-and-guards/resources/configmap_test.go
+++ b/examples/extraction-and-guards/resources/configmap_test.go
@@ -37,6 +37,9 @@ func TestConfigMapShape(t *testing.T) {
 	res, err := resources.NewConfigMapResource(owner, dbHost)
 	require.NoError(t, err)
 
-	golden.AssertYAML(t, "testdata/configmap.yaml", res.(golden.Previewer),
+	previewer, ok := res.(golden.Previewer)
+	require.True(t, ok)
+
+	golden.AssertYAML(t, "testdata/configmap.yaml", previewer,
 		golden.WithScheme(scheme), golden.Update(*update))
 }

--- a/examples/extraction-and-guards/resources/secret_test.go
+++ b/examples/extraction-and-guards/resources/secret_test.go
@@ -26,6 +26,9 @@ func TestSecretShape(t *testing.T) {
 	res, err := resources.NewSecretResource(owner, dbHost)
 	require.NoError(t, err)
 
-	golden.AssertYAML(t, "testdata/secret.yaml", res.(golden.Previewer),
+	previewer, ok := res.(golden.Previewer)
+	require.True(t, ok)
+
+	golden.AssertYAML(t, "testdata/secret.yaml", previewer,
 		golden.WithScheme(scheme), golden.Update(*update))
 }

--- a/examples/grace-inconsistency/resources/deployment_test.go
+++ b/examples/grace-inconsistency/resources/deployment_test.go
@@ -38,6 +38,9 @@ func TestDeploymentShape(t *testing.T) {
 	res, err := resources.NewDeploymentResource(owner)
 	require.NoError(t, err)
 
-	golden.AssertYAML(t, "testdata/deployment.yaml", res.(golden.Previewer),
+	previewer, ok := res.(golden.Previewer)
+	require.True(t, ok)
+
+	golden.AssertYAML(t, "testdata/deployment.yaml", previewer,
 		golden.WithScheme(testScheme()), golden.Update(*update))
 }


### PR DESCRIPTION
## Description

The resource shape tests across the examples asserted `res.(golden.Previewer)`
without checking the result. If a resource ever stopped satisfying `Previewer`,
those tests would panic rather than fail with a readable assertion. The guarded
form is already what `docs/getting-started.md` and `docs/testing.md` teach
consumers to write, and the mutation tests sitting in these same files already
guard their `concepts.MutationInspector` casts, so the examples were
contradicting both the documentation and their own neighbouring code.

## Changes

- Replace the unchecked `res.(golden.Previewer)` assertion with a
  `previewer, ok :=` form plus `require.True(t, ok)` in the six example resource
  shape tests

## Related

Supersedes #158. That PR set out to add controller-level component golden tests,
but that work has since landed on main independently as
`examples/*/app/component_test.go` with its `testdata/` snapshots. Once #158
dropped its now-duplicate controller tests, this cast guarding was the only
change it still carried, so it is being landed here against current main instead
of rebasing a branch whose two commits partly undo each other.

## Testing

`make all` passes clean (exit 0), covering unit tests, lint, formatting, the
scaffold wrapper tests, and `go build ./examples/...`. The change is confined to
test files; no example or framework behaviour moves. The six affected shape tests
still pass and their golden files are untouched, which confirms the assertions
are running against the same previewers as before rather than being skipped.