### PR TITLE
docs: use typed primitives in the guard example and pin plugin installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,37 @@ The repository ships a [Claude Code](https://code.claude.com) plugin that teache
 idioms: skills for components, primitives, custom resource wrappers, operator structure, and testing, plus scaffolding
 commands and a guidelines reviewer.
 
-Install it from this repository:
+Install it for yourself from this repository:
 
 ```
 /plugin marketplace add sourcehawk/operator-component-framework
 /plugin install ocf
 ```
+
+To share it with everyone working on your operator, commit the marketplace and plugin to your repository's
+`.claude/settings.json`. Pin `ref` to the framework tag your `go.mod` requires, so the skills Claude reads describe the
+same API you compile against:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "operator-component-framework": {
+      "source": {
+        "source": "github",
+        "repo": "sourcehawk/operator-component-framework",
+        "ref": "v0.18.0"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "ocf@operator-component-framework": true
+  }
+}
+```
+
+Collaborators are prompted to install the plugin the first time they trust the project folder. Bump `ref` in the same
+commit that bumps the framework in `go.mod`; without it the marketplace tracks the default branch and the guidance can
+drift ahead of your pinned release.
 
 Then use `/ocf:docs <topic>`, `/ocf:new-component`, `/ocf:new-wrapper`, and `/ocf:review` inside your operator project.
 

--- a/docs/component.md
+++ b/docs/component.md
@@ -682,10 +682,9 @@ func buildBackendComponent(owner *v1alpha1.WebApp) (*component.Component, error)
 
     // First resource: a config source. Once it is applied, the declared
     // extraction reads a value out of the live object and into the cell.
-    configBuilder := static.NewBuilder(newBackendConfig(owner))
-    static.ExtractInto(configBuilder, endpoint, func(obj uns.Unstructured) (string, error) {
-        value, _, err := uns.NestedString(obj.Object, "data", "endpoint")
-        return value, err
+    configBuilder := configmap.NewBuilder(newBackendConfigMap(owner))
+    configmap.ExtractInto(configBuilder, endpoint, func(cm corev1.ConfigMap) (string, error) {
+        return cm.Data["endpoint"], nil
     })
     configRes, err := configBuilder.Build()
     if err != nil {
@@ -695,18 +694,16 @@ func buildBackendComponent(owner *v1alpha1.WebApp) (*component.Component, error)
     // Second resource: a consumer that needs the endpoint. The data guard blocks
     // it until the cell is set earlier in this same reconcile cycle; the mutation
     // then injects the value at Mutate() time.
-    consumerBuilder := static.NewBuilder(newBackendConsumer(owner))
+    consumerBuilder := deployment.NewBuilder(newBackendDeployment(owner))
     consumerBuilder.WithDataGuard(endpoint)
-    consumerBuilder.WithMutation(unstruct.Mutation{
+    consumerBuilder.WithMutation(deployment.Mutation{
         Name: "set-endpoint",
-        Mutate: func(m *unstruct.Mutator) error {
+        Mutate: func(m *deployment.Mutator) error {
             value, err := endpoint.Require()
             if err != nil {
                 return err
             }
-            m.EditContent(func(e *editors.UnstructuredContentEditor) error {
-                return e.SetNestedString(value, "spec", "endpoint")
-            })
+            m.EnsureContainerEnvVar(corev1.EnvVar{Name: "BACKEND_ENDPOINT", Value: value})
             return nil
         },
     })

--- a/plugin/skills/building-components/references/component.md
+++ b/plugin/skills/building-components/references/component.md
@@ -682,10 +682,9 @@ func buildBackendComponent(owner *v1alpha1.WebApp) (*component.Component, error)
 
     // First resource: a config source. Once it is applied, the declared
     // extraction reads a value out of the live object and into the cell.
-    configBuilder := static.NewBuilder(newBackendConfig(owner))
-    static.ExtractInto(configBuilder, endpoint, func(obj uns.Unstructured) (string, error) {
-        value, _, err := uns.NestedString(obj.Object, "data", "endpoint")
-        return value, err
+    configBuilder := configmap.NewBuilder(newBackendConfigMap(owner))
+    configmap.ExtractInto(configBuilder, endpoint, func(cm corev1.ConfigMap) (string, error) {
+        return cm.Data["endpoint"], nil
     })
     configRes, err := configBuilder.Build()
     if err != nil {
@@ -695,18 +694,16 @@ func buildBackendComponent(owner *v1alpha1.WebApp) (*component.Component, error)
     // Second resource: a consumer that needs the endpoint. The data guard blocks
     // it until the cell is set earlier in this same reconcile cycle; the mutation
     // then injects the value at Mutate() time.
-    consumerBuilder := static.NewBuilder(newBackendConsumer(owner))
+    consumerBuilder := deployment.NewBuilder(newBackendDeployment(owner))
     consumerBuilder.WithDataGuard(endpoint)
-    consumerBuilder.WithMutation(unstruct.Mutation{
+    consumerBuilder.WithMutation(deployment.Mutation{
         Name: "set-endpoint",
-        Mutate: func(m *unstruct.Mutator) error {
+        Mutate: func(m *deployment.Mutator) error {
             value, err := endpoint.Require()
             if err != nil {
                 return err
             }
-            m.EditContent(func(e *editors.UnstructuredContentEditor) error {
-                return e.SetNestedString(value, "spec", "endpoint")
-            })
+            m.EnsureContainerEnvVar(corev1.EnvVar{Name: "BACKEND_ENDPOINT", Value: value})
             return nil
         },
     })


### PR DESCRIPTION
## Description

The declared-data guard example in `docs/component.md` was still written against `static.NewBuilder` and unstructured
field access, which made the generic primitive look like the way to do declared data. It isn't: the shape predates typed
data cells, and the rewrite to cells and `WithDataGuard` kept the old scaffolding instead of reshaping the example. This
swaps it for typed primitives and, separately, adds a README snippet so consumers can pin the `ocf` Claude Code plugin
to the framework version they compile against.

## Changes

- The `Blocking on declared data` example in `docs/component.md` now uses a ConfigMap producer and a Deployment
  consumer. It reads `cm.Data["endpoint"]` instead of `uns.NestedString`, and injects the value with
  `EnsureContainerEnvVar` instead of `EditContent` plus `SetNestedString`. This matches the `configmap.ExtractInto`
  snippet directly above it and the `deployment.NewBuilder` custom-guard example directly below it.
- `README.md` gains a team-install snippet for the plugin: `extraKnownMarketplaces` plus `enabledPlugins` committed to a
  consumer's own `.claude/settings.json`, with `ref` pinned to a framework release tag so the skills Claude reads
  describe the same API the project builds against.
- `plugin/skills/building-components/references/component.md` is regenerated via `make sync-plugin`.

No `pkg/` code changed, so this is documentation only.

## Challenges

The unstructured shape wasn't arbitrary, which is why it survived a rewrite. It came in with the guard docs when the
extraction API was still `WithDataExtractor(func(obj uns.Unstructured) error)`, where reaching into arbitrary JSON was
the whole point. Once extraction became typed cells, the justification went away but the code didn't. All 25 primitive
packages export `ExtractInto`, `WithDataGuard`, and `WithOptionalData`, so the typed rewrite needed no API changes.

For the plugin pin, Claude Code distinguishes a marketplace source from a plugin source: the marketplace source that
`extraKnownMarketplaces` configures accepts `ref` (branch or tag) but not `sha`. A release tag is therefore the pin that
is actually available, and the README says so rather than suggesting a commit pin that would be silently ignored.

## Testing

The rewritten example was compiled against the real API in a throwaway package under the module before being committed,
so the builder, mutator, and `ExtractInto` signatures are verified rather than assumed; the package was deleted
afterwards. The README's JSON snippet validates under `jq`. `make fmt-md` reports both files unchanged, and
`make sync-plugin` was re-run so the plugin reference mirror matches `docs/`.

Reviewers may want to check one judgment call I left alone: `plugin/skills/structuring-operators/SKILL.md` also uses
`static.NewBuilder`, but there the resource is a third-party cloud-provider CR with no typed primitive, so the
unstructured builder looks correct rather than accidental. `docs/primitives/unstructured.md`,
`docs/custom-resource.md`, and `examples/custom-resource/` keep their unstructured usage for the same reason: the
generic path is their subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnvBNAXNx7LZyyHR8ZamMU