### PR TITLE
feat(component): switch event recording to the new client-go events API

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -24,6 +24,20 @@ The framework is tested against the following version combinations:
 
 **Primary** is the version combination used in `go.mod` and in the main CI pipeline.
 
+!!! note "Obtaining an event recorder on controller-runtime v0.22"
+
+    `ReconcileContext.EventRecorder` takes a `k8s.io/client-go/tools/events.EventRecorder`, which is a client-go type
+    available in every `k8s.io/*` version in the matrix. The manager accessor that returns one,
+    `manager.GetEventRecorder(name)`, was added in controller-runtime v0.23. On v0.22.x, build the recorder from
+    client-go directly instead:
+
+    ```go
+    broadcaster := events.NewEventBroadcasterAdapter(clientset)
+    recorder := broadcaster.NewRecorder("webapp-controller")
+    ```
+
+    The framework compiles and tests unchanged against v0.22.x; only the way a consumer obtains the recorder differs.
+
 **Tested** combinations are verified weekly by the compatibility CI workflow. They are fully supported: bugs reported
 against a Tested combination are treated as bugs in the framework, not as unsupported configurations. The distinction
 from Primary is operational only (Primary is tested on every commit; Tested combinations run on a weekly schedule).

--- a/docs/component.md
+++ b/docs/component.md
@@ -508,6 +508,10 @@ optional; when set, the framework records Prometheus metrics for every condition
 recorder from [go-crd-condition-metrics](https://github.com/sourcehawk/go-crd-condition-metrics). Leave it `nil` to opt
 out.
 
+`EventRecorder` takes a `k8s.io/client-go/tools/events.EventRecorder`. The manager accessor that returns one,
+`GetEventRecorder(name)`, was added in controller-runtime v0.23; on v0.22.x, build the recorder from client-go instead,
+as described in [Compatibility](compatibility.md).
+
 ## Persisting Status with FlushStatus
 
 `Component.Reconcile` only mutates the owner's status conditions in memory. The controller persists them by calling

--- a/docs/component.md
+++ b/docs/component.md
@@ -493,11 +493,11 @@ component can ever be suspended.
 
 ```go
 recCtx := component.ReconcileContext{
-    Client:   r.Client,    // sigs.k8s.io/controller-runtime/pkg/client
-    Scheme:   r.Scheme,    // *runtime.Scheme
-    Recorder: r.Recorder,  // record.EventRecorder
-    Metrics:  r.Metrics,   // component.Recorder (condition metrics), optional
-    Owner:    owner,       // the CRD that owns this component
+    Client:        r.Client,        // sigs.k8s.io/controller-runtime/pkg/client
+    Scheme:        r.Scheme,        // *runtime.Scheme
+    EventRecorder: r.EventRecorder, // events.EventRecorder, from manager.GetEventRecorder
+    Metrics:       r.Metrics,       // component.MetricsRecorder (condition metrics), optional
+    Owner:         owner,           // the CRD that owns this component
 }
 
 err = comp.Reconcile(ctx, recCtx)
@@ -522,11 +522,11 @@ func (r *WebAppReconciler) Reconcile(ctx context.Context, req reconcile.Request)
     }
 
     recCtx := component.ReconcileContext{
-        Client:   r.Client,
-        Scheme:   r.Scheme,
-        Recorder: r.Recorder,
-        Metrics:  r.Metrics,
-        Owner:    owner,
+        Client:        r.Client,
+        Scheme:        r.Scheme,
+        EventRecorder: r.EventRecorder,
+        Metrics:       r.Metrics,
+        Owner:         owner,
     }
     defer func() {
         if flushErr := component.FlushStatus(ctx, recCtx); flushErr != nil && err == nil {

--- a/docs/component.md
+++ b/docs/component.md
@@ -495,7 +495,7 @@ component can ever be suspended.
 recCtx := component.ReconcileContext{
     Client:        r.Client,        // sigs.k8s.io/controller-runtime/pkg/client
     Scheme:        r.Scheme,        // *runtime.Scheme
-    EventRecorder: r.EventRecorder, // events.EventRecorder, from manager.GetEventRecorder
+    EventRecorder: r.EventRecorder, // events.EventRecorder, from manager.GetEventRecorder(name)
     Metrics:       r.Metrics,       // component.MetricsRecorder (condition metrics), optional
     Owner:         owner,           // the CRD that owns this component
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -266,13 +266,13 @@ self-induced update conflicts.
 
 `ReconcileContext` has five fields:
 
-| Field      | Type                    | Notes                                                                            |
-| ---------- | ----------------------- | -------------------------------------------------------------------------------- |
-| `Client`   | `client.Client`         | The controller-runtime client.                                                   |
-| `Scheme`   | `*runtime.Scheme`       | The operator scheme.                                                             |
-| `Recorder` | `record.EventRecorder`  | For Kubernetes events. Your Kubebuilder manager provides one.                    |
-| `Metrics`  | `component.Recorder`    | Optional. Pass `nil` to skip status-condition metrics.                           |
-| `Owner`    | `component.OperatorCRD` | The owner object you fetched. Your CRD satisfies this via `GetStatusConditions`. |
+| Field           | Type                        | Notes                                                                            |
+| --------------- | --------------------------- | -------------------------------------------------------------------------------- |
+| `Client`        | `client.Client`             | The controller-runtime client.                                                   |
+| `Scheme`        | `*runtime.Scheme`           | The operator scheme.                                                             |
+| `EventRecorder` | `events.EventRecorder`      | For Kubernetes events. Get one from the manager with `GetEventRecorder(name)`.   |
+| `Metrics`       | `component.MetricsRecorder` | Optional. Pass `nil` to skip status-condition metrics.                           |
+| `Owner`         | `component.OperatorCRD`     | The owner object you fetched. Your CRD satisfies this via `GetStatusConditions`. |
 
 !!! note
 
@@ -288,15 +288,15 @@ import (
 
     "github.com/sourcehawk/operator-component-framework/pkg/component"
     "k8s.io/apimachinery/pkg/runtime"
-    "k8s.io/client-go/tools/record"
+    "k8s.io/client-go/tools/events"
     "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Controller struct {
     client.Client
-    Scheme   *runtime.Scheme
-    Recorder record.EventRecorder
-    Metrics  component.Recorder
+    Scheme        *runtime.Scheme
+    EventRecorder events.EventRecorder
+    Metrics       component.MetricsRecorder
 
     NewDeploymentResource func(*ExampleApp) (component.Resource, error)
     NewConfigMapResource  func(*ExampleApp) (component.Resource, error)
@@ -304,11 +304,11 @@ type Controller struct {
 
 func (r *Controller) reconcile(ctx context.Context, owner *ExampleApp) (err error) {
     recCtx := component.ReconcileContext{
-        Client:   r.Client,
-        Scheme:   r.Scheme,
-        Recorder: r.Recorder,
-        Metrics:  r.Metrics,
-        Owner:    owner,
+        Client:        r.Client,
+        Scheme:        r.Scheme,
+        EventRecorder: r.EventRecorder,
+        Metrics:       r.Metrics,
+        Owner:         owner,
     }
     defer func() {
         if flushErr := component.FlushStatus(ctx, recCtx); flushErr != nil && err == nil {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -270,7 +270,7 @@ self-induced update conflicts.
 | --------------- | --------------------------- | -------------------------------------------------------------------------------- |
 | `Client`        | `client.Client`             | The controller-runtime client.                                                   |
 | `Scheme`        | `*runtime.Scheme`           | The operator scheme.                                                             |
-| `EventRecorder` | `events.EventRecorder`      | For Kubernetes events. Get one from the manager with `GetEventRecorder(name)`.   |
+| `EventRecorder` | `events.EventRecorder`      | For Kubernetes events. `GetEventRecorder(name)` on the manager, v0.23 and later. |
 | `Metrics`       | `component.MetricsRecorder` | Optional. Pass `nil` to skip status-condition metrics.                           |
 | `Owner`         | `component.OperatorCRD`     | The owner object you fetched. Your CRD satisfies this via `GetStatusConditions`. |
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -143,11 +143,11 @@ func (r *WebAppReconciler) Reconcile(ctx context.Context, req reconcile.Request)
     }
 
     recCtx := component.ReconcileContext{
-        Client:   r.Client,
-        Scheme:   r.Scheme,
-        Recorder: r.Recorder,
-        Metrics:  r.Metrics,
-        Owner:    app,
+        Client:        r.Client,
+        Scheme:        r.Scheme,
+        EventRecorder: r.EventRecorder,
+        Metrics:       r.Metrics,
+        Owner:         app,
     }
     // Persist all staged conditions exactly once, even on the error path.
     defer func() {

--- a/e2e/component/orphan_test.go
+++ b/e2e/component/orphan_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
@@ -47,10 +47,10 @@ var _ = Describe("OrphanWhen Garbage Collection", func() {
 		owner = framework.NewTestApp(ctx, k8sClient, ns, "orphan-owner")
 
 		recCtx = component.ReconcileContext{
-			Client:   k8sClient,
-			Scheme:   scheme.Scheme,
-			Recorder: record.NewFakeRecorder(100),
-			Owner:    owner,
+			Client:        k8sClient,
+			Scheme:        scheme.Scheme,
+			EventRecorder: events.NewFakeRecorder(100),
+			Owner:         owner,
 		}
 	})
 

--- a/e2e/component/orphan_test.go
+++ b/e2e/component/orphan_test.go
@@ -77,8 +77,17 @@ var _ = Describe("OrphanWhen Garbage Collection", func() {
 		Expect(k8sClient.Create(ctx, orphaned)).To(Succeed())
 
 		By("verifying both ConfigMaps start with the owner reference")
-		Expect(ownerReferenceUIDs(ctx, ns, "control-cm")).To(ContainElement(owner.UID))
-		Expect(ownerReferenceUIDs(ctx, ns, "orphan-cm")).To(ContainElement(owner.UID))
+		// k8sClient is the manager's cached client, so an object that was just created
+		// can still be absent from the informer cache. Poll both reads rather than
+		// asserting once, or a cold cache fails the spec before it tests anything.
+		Eventually(func(g Gomega) []types.UID {
+			return ownerReferenceUIDsG(g, ctx, ns, "control-cm")
+		}, framework.DefaultTimeout, framework.DefaultPolling).
+			Should(ContainElement(owner.UID))
+		Eventually(func(g Gomega) []types.UID {
+			return ownerReferenceUIDsG(g, ctx, ns, "orphan-cm")
+		}, framework.DefaultTimeout, framework.DefaultPolling).
+			Should(ContainElement(owner.UID))
 
 		By("reconciling a component that orphans the target ConfigMap")
 		orphanRes, err := configmap.NewBuilder(

--- a/e2e/component/suite_test.go
+++ b/e2e/component/suite_test.go
@@ -13,7 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -54,7 +54,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("creating E2E reconciler")
-	recorder := record.NewFakeRecorder(1000)
+	recorder := events.NewFakeRecorder(1000)
 	metrics := &ocm.ConditionMetricRecorder{
 		Controller:              "e2e-component",
 		OperatorConditionsGauge: ocm.NewOperatorConditionsGauge("e2e_component"),

--- a/e2e/framework/cluster_reconciler.go
+++ b/e2e/framework/cluster_reconciler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcehawk/operator-component-framework/pkg/component"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -28,9 +28,9 @@ type ClusterComponentFactory func(owner *ClusterTestApp) (*component.Component, 
 // cluster-scoped ClusterTestApp resources for testing cluster-scoped primitives.
 type ClusterE2EReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Metrics  component.Recorder
+	Scheme        *runtime.Scheme
+	EventRecorder events.EventRecorder
+	Metrics       component.MetricsRecorder
 
 	mu                 sync.RWMutex
 	resourceFactories  map[string]ClusterResourceFactory
@@ -41,13 +41,13 @@ type ClusterE2EReconciler struct {
 func NewClusterE2EReconciler(
 	c client.Client,
 	scheme *runtime.Scheme,
-	recorder record.EventRecorder,
-	metrics component.Recorder,
+	recorder events.EventRecorder,
+	metrics component.MetricsRecorder,
 ) *ClusterE2EReconciler {
 	return &ClusterE2EReconciler{
 		Client:             c,
 		Scheme:             scheme,
-		Recorder:           recorder,
+		EventRecorder:      recorder,
 		Metrics:            metrics,
 		resourceFactories:  make(map[string]ClusterResourceFactory),
 		componentFactories: make(map[string]ClusterComponentFactory),
@@ -123,11 +123,11 @@ func (r *ClusterE2EReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 	}
 
 	recCtx := component.ReconcileContext{
-		Client:   r.Client,
-		Scheme:   r.Scheme,
-		Recorder: r.Recorder,
-		Metrics:  r.Metrics,
-		Owner:    owner,
+		Client:        r.Client,
+		Scheme:        r.Scheme,
+		EventRecorder: r.EventRecorder,
+		Metrics:       r.Metrics,
+		Owner:         owner,
 	}
 	defer func() {
 		if flushErr := component.FlushStatus(ctx, recCtx); flushErr != nil && err == nil {

--- a/e2e/framework/reconciler.go
+++ b/e2e/framework/reconciler.go
@@ -8,7 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -28,9 +28,9 @@ type ComponentFactory func(owner *TestApp) (*component.Component, error)
 // construction to per-test factories registered by namespace/name key.
 type E2EReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Metrics  component.Recorder
+	Scheme        *runtime.Scheme
+	EventRecorder events.EventRecorder
+	Metrics       component.MetricsRecorder
 
 	mu                 sync.RWMutex
 	resourceFactories  map[string]ResourceFactory
@@ -41,13 +41,13 @@ type E2EReconciler struct {
 func NewE2EReconciler(
 	c client.Client,
 	scheme *runtime.Scheme,
-	recorder record.EventRecorder,
-	metrics component.Recorder,
+	recorder events.EventRecorder,
+	metrics component.MetricsRecorder,
 ) *E2EReconciler {
 	return &E2EReconciler{
 		Client:             c,
 		Scheme:             scheme,
-		Recorder:           recorder,
+		EventRecorder:      recorder,
 		Metrics:            metrics,
 		resourceFactories:  make(map[string]ResourceFactory),
 		componentFactories: make(map[string]ComponentFactory),
@@ -123,11 +123,11 @@ func (r *E2EReconciler) Reconcile(ctx context.Context, req reconcile.Request) (_
 	}
 
 	recCtx := component.ReconcileContext{
-		Client:   r.Client,
-		Scheme:   r.Scheme,
-		Recorder: r.Recorder,
-		Metrics:  r.Metrics,
-		Owner:    owner,
+		Client:        r.Client,
+		Scheme:        r.Scheme,
+		EventRecorder: r.EventRecorder,
+		Metrics:       r.Metrics,
+		Owner:         owner,
 	}
 	defer func() {
 		if flushErr := component.FlushStatus(ctx, recCtx); flushErr != nil && err == nil {

--- a/e2e/primitives/suite_test.go
+++ b/e2e/primitives/suite_test.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("creating E2E reconcilers")
-	recorder := record.NewFakeRecorder(1000)
+	recorder := events.NewFakeRecorder(1000)
 	metrics := &ocm.ConditionMetricRecorder{
 		Controller:              "e2e-primitives",
 		OperatorConditionsGauge: ocm.NewOperatorConditionsGauge("e2e_primitives"),

--- a/examples/component-prerequisites/app/controller.go
+++ b/examples/component-prerequisites/app/controller.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/sourcehawk/operator-component-framework/pkg/component"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -18,9 +18,9 @@ import (
 // will not proceed until the infra component's condition is True.
 type Controller struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Metrics  component.Recorder
+	Scheme        *runtime.Scheme
+	EventRecorder events.EventRecorder
+	Metrics       component.MetricsRecorder
 
 	NewConfigMapResource  func(*ExampleApp) (component.Resource, error)
 	NewDeploymentResource func(*ExampleApp) (component.Resource, error)
@@ -35,11 +35,11 @@ type Controller struct {
 // against the same owner and hitting conflicts.
 func (r *Controller) Reconcile(ctx context.Context, owner *ExampleApp) (err error) {
 	recCtx := component.ReconcileContext{
-		Client:   r.Client,
-		Scheme:   r.Scheme,
-		Recorder: r.Recorder,
-		Metrics:  r.Metrics,
-		Owner:    owner,
+		Client:        r.Client,
+		Scheme:        r.Scheme,
+		EventRecorder: r.EventRecorder,
+		Metrics:       r.Metrics,
+		Owner:         owner,
 	}
 	defer func() {
 		if flushErr := component.FlushStatus(ctx, recCtx); flushErr != nil && err == nil {

--- a/examples/component-prerequisites/main.go
+++ b/examples/component-prerequisites/main.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 func main() {
@@ -47,9 +47,9 @@ func main() {
 
 	gauge := ocm.NewOperatorConditionsGauge("example")
 	controller := &app.Controller{
-		Client:   fakeClient,
-		Scheme:   scheme,
-		Recorder: record.NewFakeRecorder(100),
+		Client:        fakeClient,
+		Scheme:        scheme,
+		EventRecorder: events.NewFakeRecorder(100),
 		Metrics: &ocm.ConditionMetricRecorder{
 			Controller:              "example",
 			OperatorConditionsGauge: gauge,

--- a/examples/custom-resource/app/controller.go
+++ b/examples/custom-resource/app/controller.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sourcehawk/operator-component-framework/pkg/component"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -15,9 +15,9 @@ import (
 // resource using the unstructured static builder.
 type Controller struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Metrics  component.Recorder
+	Scheme        *runtime.Scheme
+	EventRecorder events.EventRecorder
+	Metrics       component.MetricsRecorder
 
 	NewCertificateResource func(*ExampleApp) (component.Resource, error)
 }
@@ -25,11 +25,11 @@ type Controller struct {
 // Reconcile builds and reconciles a single component managing the certificate.
 func (r *Controller) Reconcile(ctx context.Context, owner *ExampleApp) (err error) {
 	recCtx := component.ReconcileContext{
-		Client:   r.Client,
-		Scheme:   r.Scheme,
-		Recorder: r.Recorder,
-		Metrics:  r.Metrics,
-		Owner:    owner,
+		Client:        r.Client,
+		Scheme:        r.Scheme,
+		EventRecorder: r.EventRecorder,
+		Metrics:       r.Metrics,
+		Owner:         owner,
 	}
 	defer func() {
 		if flushErr := component.FlushStatus(ctx, recCtx); flushErr != nil && err == nil {

--- a/examples/custom-resource/main.go
+++ b/examples/custom-resource/main.go
@@ -19,7 +19,7 @@ import (
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 func main() {
@@ -59,9 +59,9 @@ func main() {
 
 	gauge := ocm.NewOperatorConditionsGauge("example")
 	controller := &app.Controller{
-		Client:   fakeClient,
-		Scheme:   scheme,
-		Recorder: record.NewFakeRecorder(100),
+		Client:        fakeClient,
+		Scheme:        scheme,
+		EventRecorder: events.NewFakeRecorder(100),
 		Metrics: &ocm.ConditionMetricRecorder{
 			Controller:              "example",
 			OperatorConditionsGauge: gauge,

--- a/examples/extraction-and-guards/app/controller.go
+++ b/examples/extraction-and-guards/app/controller.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcehawk/operator-component-framework/pkg/component"
 	"github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,9 +16,9 @@ import (
 // extraction, and the Secret is guarded until that data is available.
 type Controller struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Metrics  component.Recorder
+	Scheme        *runtime.Scheme
+	EventRecorder events.EventRecorder
+	Metrics       component.MetricsRecorder
 
 	// NewConfigMapResource builds the ConfigMap and declares the extraction
 	// that writes the dbHost cell.
@@ -34,11 +34,11 @@ type Controller struct {
 // only read data extracted by a preceding resource.
 func (r *Controller) Reconcile(ctx context.Context, owner *ExampleApp) (err error) {
 	recCtx := component.ReconcileContext{
-		Client:   r.Client,
-		Scheme:   r.Scheme,
-		Recorder: r.Recorder,
-		Metrics:  r.Metrics,
-		Owner:    owner,
+		Client:        r.Client,
+		Scheme:        r.Scheme,
+		EventRecorder: r.EventRecorder,
+		Metrics:       r.Metrics,
+		Owner:         owner,
 	}
 	defer func() {
 		if flushErr := component.FlushStatus(ctx, recCtx); flushErr != nil && err == nil {

--- a/examples/extraction-and-guards/main.go
+++ b/examples/extraction-and-guards/main.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 func main() {
@@ -46,9 +46,9 @@ func main() {
 
 	gauge := ocm.NewOperatorConditionsGauge("example")
 	controller := &app.Controller{
-		Client:   fakeClient,
-		Scheme:   scheme,
-		Recorder: record.NewFakeRecorder(100),
+		Client:        fakeClient,
+		Scheme:        scheme,
+		EventRecorder: events.NewFakeRecorder(100),
 		Metrics: &ocm.ConditionMetricRecorder{
 			Controller:              "example",
 			OperatorConditionsGauge: gauge,

--- a/examples/grace-inconsistency/app/controller.go
+++ b/examples/grace-inconsistency/app/controller.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sourcehawk/operator-component-framework/pkg/component"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -17,9 +17,9 @@ import (
 // SuppressGraceInconsistencyWarning() option.
 type Controller struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Metrics  component.Recorder
+	Scheme        *runtime.Scheme
+	EventRecorder events.EventRecorder
+	Metrics       component.MetricsRecorder
 
 	NewDeploymentResource func(*ExampleApp) (component.Resource, error)
 }
@@ -28,11 +28,11 @@ type Controller struct {
 // inconsistency suppression.
 func (r *Controller) Reconcile(ctx context.Context, owner *ExampleApp) (err error) {
 	recCtx := component.ReconcileContext{
-		Client:   r.Client,
-		Scheme:   r.Scheme,
-		Recorder: r.Recorder,
-		Metrics:  r.Metrics,
-		Owner:    owner,
+		Client:        r.Client,
+		Scheme:        r.Scheme,
+		EventRecorder: r.EventRecorder,
+		Metrics:       r.Metrics,
+		Owner:         owner,
 	}
 	defer func() {
 		if flushErr := component.FlushStatus(ctx, recCtx); flushErr != nil && err == nil {

--- a/examples/grace-inconsistency/main.go
+++ b/examples/grace-inconsistency/main.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 func main() {
@@ -45,9 +45,9 @@ func main() {
 
 	gauge := ocm.NewOperatorConditionsGauge("example")
 	controller := &app.Controller{
-		Client:   fakeClient,
-		Scheme:   scheme,
-		Recorder: record.NewFakeRecorder(100),
+		Client:        fakeClient,
+		Scheme:        scheme,
+		EventRecorder: events.NewFakeRecorder(100),
 		Metrics: &ocm.ConditionMetricRecorder{
 			Controller:              "example",
 			OperatorConditionsGauge: gauge,

--- a/examples/mutations-and-gating/app/controller.go
+++ b/examples/mutations-and-gating/app/controller.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/sourcehawk/operator-component-framework/pkg/component"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -15,9 +15,9 @@ import (
 // created only when metrics are enabled and deleted when they are disabled.
 type Controller struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Metrics  component.Recorder
+	Scheme        *runtime.Scheme
+	EventRecorder events.EventRecorder
+	Metrics       component.MetricsRecorder
 
 	NewDeploymentResource func(*ExampleApp) (component.Resource, error)
 	NewConfigMapResource  func(*ExampleApp) (component.Resource, error)
@@ -26,11 +26,11 @@ type Controller struct {
 // Reconcile builds and reconciles a single component containing both resources.
 func (r *Controller) Reconcile(ctx context.Context, owner *ExampleApp) (err error) {
 	recCtx := component.ReconcileContext{
-		Client:   r.Client,
-		Scheme:   r.Scheme,
-		Recorder: r.Recorder,
-		Metrics:  r.Metrics,
-		Owner:    owner,
+		Client:        r.Client,
+		Scheme:        r.Scheme,
+		EventRecorder: r.EventRecorder,
+		Metrics:       r.Metrics,
+		Owner:         owner,
 	}
 	defer func() {
 		if flushErr := component.FlushStatus(ctx, recCtx); flushErr != nil && err == nil {

--- a/examples/mutations-and-gating/main.go
+++ b/examples/mutations-and-gating/main.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 func main() {
@@ -51,9 +51,9 @@ func main() {
 
 	gauge := ocm.NewOperatorConditionsGauge("example")
 	controller := &app.Controller{
-		Client:   fakeClient,
-		Scheme:   scheme,
-		Recorder: record.NewFakeRecorder(100),
+		Client:        fakeClient,
+		Scheme:        scheme,
+		EventRecorder: events.NewFakeRecorder(100),
 		Metrics: &ocm.ConditionMetricRecorder{
 			Controller:              "example",
 			OperatorConditionsGauge: gauge,

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -51,7 +51,7 @@ type ReconcileContext struct {
 	// Scheme is the runtime scheme for the operator.
 	Scheme *runtime.Scheme
 	// EventRecorder is the event recorder for publishing Kubernetes events.
-	// Obtain one from the controller-runtime manager with GetEventRecorder.
+	// Obtain one from the controller-runtime manager with GetEventRecorder(name).
 	EventRecorder events.EventRecorder
 	// Metrics is the recorder for status condition metrics. It is optional; if
 	// nil, [FlushStatus] will skip metric emission.

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -32,10 +32,10 @@ type OperatorCRD interface {
 	GetKind() string
 }
 
-// Recorder is an interface for recording status condition changes as metrics.
+// MetricsRecorder is an interface for recording status condition changes as metrics.
 // It is optional: a [ReconcileContext] may leave [ReconcileContext.Metrics]
 // nil, in which case [FlushStatus] skips metric emission.
-type Recorder interface {
+type MetricsRecorder interface {
 	// RecordConditionFor records a condition change for a specific object and kind.
 	RecordConditionFor(
 		kind string, object ocm.ObjectLike,
@@ -50,11 +50,12 @@ type ReconcileContext struct {
 	Client client.Client
 	// Scheme is the runtime scheme for the operator.
 	Scheme *runtime.Scheme
-	// Recorder is the event recorder for publishing Kubernetes events.
-	Recorder record.EventRecorder
+	// EventRecorder is the event recorder for publishing Kubernetes events.
+	// Obtain one from the controller-runtime manager with GetEventRecorder.
+	EventRecorder events.EventRecorder
 	// Metrics is the recorder for status condition metrics. It is optional; if
 	// nil, [FlushStatus] will skip metric emission.
-	Metrics Recorder
+	Metrics MetricsRecorder
 	// Owner is the custom resource that owns and is updated by the components.
 	Owner OperatorCRD
 }

--- a/pkg/component/create.go
+++ b/pkg/component/create.go
@@ -108,7 +108,7 @@ func applyResource(
 		)
 	}
 
-	recording.RecordApplyOperationEvent(rec.Recorder, convergingOperation, obj, rec.Owner)
+	recording.RecordApplyOperationEvent(rec.EventRecorder, convergingOperation, obj, rec.Owner)
 
 	if status != nil {
 		return &reconcileResult{Status: *status}, nil

--- a/pkg/component/delete.go
+++ b/pkg/component/delete.go
@@ -68,8 +68,8 @@ func deleteResources(
 			continue
 		}
 
-		rec.Recorder.Eventf(
-			rec.Owner, v1.EventTypeNormal, "ResourceDeleted",
+		rec.EventRecorder.Eventf(
+			rec.Owner, object, v1.EventTypeNormal, "ResourceDeleted", "Delete",
 			"Resource %s deleted due to %s", resource.Identity(), cfg.reason,
 		)
 	}

--- a/pkg/component/delete_test.go
+++ b/pkg/component/delete_test.go
@@ -158,4 +158,60 @@ func TestDeleteResources(t *testing.T) {
 		resource1.AssertExpectations(t)
 		resource2.AssertExpectations(t)
 	})
+
+	t.Run("should record a deletion event carrying the deleted object and reason", func(t *testing.T) {
+		// Given
+		resourceObject := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cm-event",
+				Namespace: namespace,
+			},
+		}
+		require.NoError(t, fakeClient.Create(ctx, resourceObject.DeepCopy()))
+
+		resource := &MockResource{}
+		resource.On("Object").Return(resourceObject, nil)
+		resource.On("Identity").Return("v1/ConfigMap/test-cm-event")
+
+		recCtx := setupReconcileContext(scheme, owner, fakeClient)
+
+		// When
+		err := deleteResources(ctx, recCtx, []Resource{resource}, withDeletionReason("suspension"))
+
+		// Then
+		require.NoError(t, err)
+
+		recorder, ok := recCtx.EventRecorder.(*spyRecorder)
+		require.True(t, ok)
+
+		deletions := recorder.recordedWithReason("ResourceDeleted")
+		require.Len(t, deletions, 1)
+		assert.Equal(t, owner, deletions[0].regarding, "event is recorded on the owner")
+		assert.Equal(t, "test-cm-event", deletions[0].related.(client.Object).GetName(),
+			"deleted resource is attached as the related object")
+		assert.Equal(t, corev1.EventTypeNormal, deletions[0].eventType)
+		assert.Equal(t, "Delete", deletions[0].action)
+		assert.Equal(t, "Resource v1/ConfigMap/test-cm-event deleted due to suspension", deletions[0].note)
+	})
+
+	t.Run("should record no event when the resource is already gone", func(t *testing.T) {
+		// Given
+		resource := &MockResource{}
+		resource.On("Object").Return(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm-absent", Namespace: namespace},
+		}, nil)
+		resource.On("Identity").Return("v1/ConfigMap/test-cm-absent")
+
+		recCtx := setupReconcileContext(scheme, owner, fakeClient)
+
+		// When
+		err := deleteResources(ctx, recCtx, []Resource{resource})
+
+		// Then
+		require.NoError(t, err)
+
+		recorder, ok := recCtx.EventRecorder.(*spyRecorder)
+		require.True(t, ok)
+		assert.Empty(t, recorder.recorded())
+	})
 }

--- a/pkg/component/orphan.go
+++ b/pkg/component/orphan.go
@@ -36,7 +36,10 @@ func orphanResources(ctx context.Context, rec ReconcileContext, resources []Reso
 		}
 		key := client.ObjectKeyFromObject(obj)
 
-		var removed bool
+		var (
+			removed  bool
+			orphaned client.Object
+		)
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			live := obj.DeepCopyObject().(client.Object)
 			if getErr := rec.Client.Get(ctx, key, live); getErr != nil {
@@ -59,14 +62,18 @@ func orphanResources(ctx context.Context, rec ReconcileContext, resources []Reso
 				return nil
 			}
 			live.SetOwnerReferences(kept)
-			return rec.Client.Update(ctx, live)
+			if updateErr := rec.Client.Update(ctx, live); updateErr != nil {
+				return updateErr
+			}
+			orphaned = live
+			return nil
 		})
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to orphan resource %s: %w", resource.Identity(), err))
 			continue
 		}
 		if removed {
-			rec.Recorder.Eventf(rec.Owner, v1.EventTypeNormal, "ResourceOrphaned",
+			rec.EventRecorder.Eventf(rec.Owner, orphaned, v1.EventTypeNormal, "ResourceOrphaned", "Orphan",
 				"Resource %s orphaned: owner reference removed", resource.Identity())
 		}
 	}

--- a/pkg/component/orphan.go
+++ b/pkg/component/orphan.go
@@ -41,6 +41,12 @@ func orphanResources(ctx context.Context, rec ReconcileContext, resources []Reso
 			orphaned client.Object
 		)
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// Each attempt reports only what it observed itself. Without this reset, an
+			// attempt that conflicts after setting removed would leak that state into a
+			// later attempt whose object has since been deleted, and the event would
+			// claim an orphaning that never landed.
+			removed, orphaned = false, nil
+
 			live := obj.DeepCopyObject().(client.Object)
 			if getErr := rec.Client.Get(ctx, key, live); getErr != nil {
 				if apierrors.IsNotFound(getErr) {
@@ -50,7 +56,6 @@ func orphanResources(ctx context.Context, rec ReconcileContext, resources []Reso
 			}
 			refs := live.GetOwnerReferences()
 			kept := make([]metav1.OwnerReference, 0, len(refs))
-			removed = false
 			for _, ref := range refs {
 				if ref.UID == ownerUID {
 					removed = true

--- a/pkg/component/orphan_test.go
+++ b/pkg/component/orphan_test.go
@@ -57,6 +57,31 @@ func TestOrphanResources(t *testing.T) {
 		res.On("Identity").Return("v1/ConfigMap/missing")
 		require.NoError(t, orphanResources(t.Context(), setupReconcileContext(scheme, owner, fc), []Resource{res}))
 	})
+	t.Run("records an orphan event carrying the released object", func(t *testing.T) {
+		owner := newOwner()
+		_, rc, res := seed(t, owner, ownerRef("owner-uid", "test-owner"))
+		require.NoError(t, orphanResources(t.Context(), rc, []Resource{res}))
+
+		recorder, ok := rc.EventRecorder.(*spyRecorder)
+		require.True(t, ok)
+
+		orphaned := recorder.recordedWithReason("ResourceOrphaned")
+		require.Len(t, orphaned, 1)
+		assert.Equal(t, owner, orphaned[0].regarding, "event is recorded on the owner")
+		assert.Equal(t, "test-cm", orphaned[0].related.(client.Object).GetName(),
+			"released resource is attached as the related object")
+		assert.Equal(t, corev1.EventTypeNormal, orphaned[0].eventType)
+		assert.Equal(t, "Orphan", orphaned[0].action)
+		assert.Equal(t, "Resource v1/ConfigMap/test-cm orphaned: owner reference removed", orphaned[0].note)
+	})
+	t.Run("records no event when the owner reference was already absent", func(t *testing.T) {
+		_, rc, res := seed(t, newOwner())
+		require.NoError(t, orphanResources(t.Context(), rc, []Resource{res}))
+
+		recorder, ok := rc.EventRecorder.(*spyRecorder)
+		require.True(t, ok)
+		assert.Empty(t, recorder.recorded())
+	})
 	t.Run("removes only this owner's reference", func(t *testing.T) {
 		fc, rc, res := seed(t, newOwner(), ownerRef("owner-uid", "test-owner"), ownerRef("other-uid", "other-owner"))
 		require.NoError(t, orphanResources(t.Context(), rc, []Resource{res}))

--- a/pkg/component/orphan_test.go
+++ b/pkg/component/orphan_test.go
@@ -1,12 +1,16 @@
 package component
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -81,6 +85,37 @@ func TestOrphanResources(t *testing.T) {
 		recorder, ok := rc.EventRecorder.(*spyRecorder)
 		require.True(t, ok)
 		assert.Empty(t, recorder.recorded())
+	})
+	t.Run("records no event when the object is deleted between a conflicting update and the retry", func(t *testing.T) {
+		owner := newOwner()
+		scheme := setupScheme()
+		gvr := schema.GroupResource{Resource: "configmaps"}
+
+		// First attempt finds the owner reference and conflicts on update; by the time
+		// the retry re-reads the object, it is gone. Nothing was orphaned.
+		mockClient := &MockClient{}
+		mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				live := args.Get(2).(client.Object)
+				live.SetOwnerReferences([]metav1.OwnerReference{ownerRef("owner-uid", "test-owner")})
+			}).Return(nil).Once()
+		mockClient.On("Update", mock.Anything, mock.Anything, mock.Anything).
+			Return(apierrors.NewConflict(gvr, "test-cm", errors.New("object was modified"))).Once()
+		mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(apierrors.NewNotFound(gvr, "test-cm")).Once()
+
+		res := &MockResource{}
+		res.On("Object").Return(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: ns}}, nil)
+		res.On("Identity").Return("v1/ConfigMap/test-cm")
+
+		rc := setupReconcileContext(scheme, owner, mockClient)
+		require.NoError(t, orphanResources(t.Context(), rc, []Resource{res}))
+
+		recorder, ok := rc.EventRecorder.(*spyRecorder)
+		require.True(t, ok)
+		assert.Empty(t, recorder.recorded(), "no orphan event for an object that was deleted before it could be orphaned")
+
+		mockClient.AssertExpectations(t)
 	})
 	t.Run("removes only this owner's reference", func(t *testing.T) {
 		fc, rc, res := seed(t, newOwner(), ownerRef("owner-uid", "test-owner"), ownerRef("other-uid", "other-owner"))

--- a/pkg/component/suite_test.go
+++ b/pkg/component/suite_test.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -92,9 +91,9 @@ func createNamespace(ctx context.Context, prefix string) string {
 
 func newTestReconcileContext(owner OperatorCRD) ReconcileContext {
 	return ReconcileContext{
-		Client:   k8sClient,
-		Scheme:   scheme.Scheme,
-		Recorder: record.NewFakeRecorder(100),
+		Client:        k8sClient,
+		Scheme:        scheme.Scheme,
+		EventRecorder: &spyRecorder{},
 		Metrics: &ocm.ConditionMetricRecorder{
 			Controller:              "test-controller",
 			OperatorConditionsGauge: ocm.NewOperatorConditionsGauge("test_namespace"),

--- a/pkg/component/suspend.go
+++ b/pkg/component/suspend.go
@@ -167,8 +167,8 @@ func suspendResource(
 			}
 		}
 
-		rec.Recorder.Eventf(
-			rec.Owner, v1.EventTypeNormal, "ResourceDeleted",
+		rec.EventRecorder.Eventf(
+			rec.Owner, object, v1.EventTypeNormal, "ResourceDeleted", "Delete",
 			"Resource %s deleted on suspension", resource.Identity(),
 		)
 

--- a/pkg/component/suspend_test.go
+++ b/pkg/component/suspend_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -260,20 +259,17 @@ func TestSuspendResource(t *testing.T) {
 		err = cli.Get(ctx, client.ObjectKeyFromObject(obj), &v1.ConfigMap{})
 		assert.True(t, apierrors.IsNotFound(err))
 
-		recorder := rec.Recorder.(*record.FakeRecorder)
+		recorder, ok := rec.EventRecorder.(*spyRecorder)
+		require.True(t, ok)
 
-		// Drain the "UpdatedConfigMap" event from applyResources
-		select {
-		case <-recorder.Events:
-		default:
-		}
-
-		select {
-		case event := <-recorder.Events:
-			assert.Contains(t, event, "ResourceDeleted")
-		default:
-			t.Fatal("expected event but none found")
-		}
+		deletions := recorder.recordedWithReason("ResourceDeleted")
+		require.Len(t, deletions, 1)
+		assert.Equal(t, owner, deletions[0].regarding, "event is recorded on the owner")
+		assert.Equal(t, obj.GetName(), deletions[0].related.(client.Object).GetName(),
+			"deleted resource is attached as the related object")
+		assert.Equal(t, v1.EventTypeNormal, deletions[0].eventType)
+		assert.Equal(t, "Delete", deletions[0].action)
+		assert.Contains(t, deletions[0].note, "deleted on suspension")
 	})
 
 	t.Run("should not delete if suspension is not completed", func(t *testing.T) {

--- a/pkg/component/zz_setup_test.go
+++ b/pkg/component/zz_setup_test.go
@@ -1,14 +1,70 @@
 package component
 
 import (
+	"fmt"
+	"sync"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ocm "github.com/sourcehawk/go-crd-condition-metrics/pkg/crd-condition-metrics"
 )
+
+// recordedEvent captures every argument handed to [events.EventRecorder.Eventf].
+// The client-go fake recorder collapses events into a string and drops the
+// related object and the action, both of which are asserted on here.
+type recordedEvent struct {
+	regarding runtime.Object
+	related   runtime.Object
+	eventType string
+	reason    string
+	action    string
+	note      string
+}
+
+// spyRecorder is an [events.EventRecorder] that records events in memory.
+type spyRecorder struct {
+	mu     sync.Mutex
+	events []recordedEvent
+}
+
+var _ events.EventRecorder = &spyRecorder{}
+
+func (s *spyRecorder) Eventf(
+	regarding, related runtime.Object, eventtype, reason, action, note string, args ...any,
+) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, recordedEvent{
+		regarding: regarding,
+		related:   related,
+		eventType: eventtype,
+		reason:    reason,
+		action:    action,
+		note:      fmt.Sprintf(note, args...),
+	})
+}
+
+// recorded returns a copy of the events captured so far.
+func (s *spyRecorder) recorded() []recordedEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]recordedEvent(nil), s.events...)
+}
+
+// recordedWithReason returns the captured events matching the given reason.
+func (s *spyRecorder) recordedWithReason(reason string) []recordedEvent {
+	var matching []recordedEvent
+	for _, event := range s.recorded() {
+		if event.reason == reason {
+			matching = append(matching, event)
+		}
+	}
+	return matching
+}
 
 func setupScheme() *runtime.Scheme {
 	s := scheme.Scheme
@@ -19,9 +75,9 @@ func setupScheme() *runtime.Scheme {
 
 func setupReconcileContext(scheme *runtime.Scheme, owner *MockOperatorCRD, client client.Client) ReconcileContext {
 	return ReconcileContext{
-		Client:   client,
-		Scheme:   scheme,
-		Recorder: record.NewFakeRecorder(10),
+		Client:        client,
+		Scheme:        scheme,
+		EventRecorder: &spyRecorder{},
 		Metrics: &ocm.ConditionMetricRecorder{
 			Controller:              "test-controller",
 			OperatorConditionsGauge: ocm.NewOperatorConditionsGauge("test_namespace"),

--- a/pkg/recording/resource_event.go
+++ b/pkg/recording/resource_event.go
@@ -72,10 +72,12 @@ func applyOperationMessage(op concepts.ConvergingOperation, object client.Object
 // for its owning resource (owner).
 //
 // The event is recorded on the owner, with the applied object attached as the event's
-// related object and the operation verb ("Create" or "Update") as its action.
+// related object and the operation verb as its action.
 //
 //   - ConvergingOperationNone: No event is recorded
-//   - Other operations: An event of type Normal is recorded
+//   - ConvergingOperationCreated: An event of type Normal with the action "Create"
+//   - ConvergingOperationUpdated: An event of type Normal with the action "Update"
+//   - Any other operation value: An event of type Normal with the action "Unchanged"
 //   - messageKeyValuePairs are strings expected in the format "myKey=myValue" and are prepended to the generated
 //     event message for additional information
 func RecordApplyOperationEvent(

--- a/pkg/recording/resource_event.go
+++ b/pkg/recording/resource_event.go
@@ -11,7 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -43,6 +43,20 @@ func applyOperationReason(op concepts.ConvergingOperation, object client.Object)
 	}
 }
 
+// applyOperationAction returns the event action verb for the operation. It is
+// only meaningful for operations that changed the object; ConvergingOperationNone
+// never reaches the recorder.
+func applyOperationAction(op concepts.ConvergingOperation) string {
+	switch op {
+	case concepts.ConvergingOperationCreated:
+		return "Create"
+	case concepts.ConvergingOperationUpdated:
+		return "Update"
+	default:
+		return "Unchanged"
+	}
+}
+
 func applyOperationMessage(op concepts.ConvergingOperation, object client.Object) string {
 	switch op {
 	case concepts.ConvergingOperationCreated:
@@ -57,12 +71,15 @@ func applyOperationMessage(op concepts.ConvergingOperation, object client.Object
 // RecordApplyOperationEvent records an event for Server-Side Apply operations on a resource (object)
 // for its owning resource (owner).
 //
+// The event is recorded on the owner, with the applied object attached as the event's
+// related object and the operation verb ("Create" or "Update") as its action.
+//
 //   - ConvergingOperationNone: No event is recorded
 //   - Other operations: An event of type Normal is recorded
 //   - messageKeyValuePairs are strings expected in the format "myKey=myValue" and are prepended to the generated
 //     event message for additional information
 func RecordApplyOperationEvent(
-	recorder record.EventRecorder, op concepts.ConvergingOperation, object client.Object, owner runtime.Object,
+	recorder events.EventRecorder, op concepts.ConvergingOperation, object client.Object, owner runtime.Object,
 	messageKeyValuePairs ...string,
 ) {
 	if op == concepts.ConvergingOperationNone {
@@ -73,5 +90,8 @@ func RecordApplyOperationEvent(
 		message = fmt.Sprintf("%s (%s)", message, strings.Join(messageKeyValuePairs, ", "))
 	}
 
-	recorder.Event(owner, v1.EventTypeNormal, applyOperationReason(op, object), message)
+	recorder.Eventf(
+		owner, object, v1.EventTypeNormal,
+		applyOperationReason(op, object), applyOperationAction(op), "%s", message,
+	)
 }

--- a/pkg/recording/resource_event.go
+++ b/pkg/recording/resource_event.go
@@ -43,9 +43,9 @@ func applyOperationReason(op concepts.ConvergingOperation, object client.Object)
 	}
 }
 
-// applyOperationAction returns the event action verb for the operation. It is
-// only meaningful for operations that changed the object; ConvergingOperationNone
-// never reaches the recorder.
+// applyOperationAction returns the event action verb for the operation.
+// ConvergingOperationNone never reaches the recorder; any value other than
+// Created or Updated is reported as "Unchanged", mirroring applyOperationReason.
 func applyOperationAction(op concepts.ConvergingOperation) string {
 	switch op {
 	case concepts.ConvergingOperationCreated:
@@ -78,8 +78,8 @@ func applyOperationMessage(op concepts.ConvergingOperation, object client.Object
 //   - ConvergingOperationCreated: An event of type Normal with the action "Create"
 //   - ConvergingOperationUpdated: An event of type Normal with the action "Update"
 //   - Any other operation value: An event of type Normal with the action "Unchanged"
-//   - messageKeyValuePairs are strings expected in the format "myKey=myValue" and are prepended to the generated
-//     event message for additional information
+//   - messageKeyValuePairs are strings expected in the format "myKey=myValue". They are appended to the
+//     generated event message in parentheses, comma-separated, for additional information
 func RecordApplyOperationEvent(
 	recorder events.EventRecorder, op concepts.ConvergingOperation, object client.Object, owner runtime.Object,
 	messageKeyValuePairs ...string,

--- a/pkg/recording/resource_event_test.go
+++ b/pkg/recording/resource_event_test.go
@@ -1,18 +1,52 @@
 package recording
 
 import (
-	"strings"
+	"fmt"
 	"testing"
 
 	"github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// recordedEvent captures every argument handed to [events.EventRecorder.Eventf].
+// The client-go fake recorder collapses events into a string and drops the
+// related object and the action, which are exactly the fields under test here.
+type recordedEvent struct {
+	regarding runtime.Object
+	related   runtime.Object
+	eventType string
+	reason    string
+	action    string
+	note      string
+}
+
+// spyRecorder is an [events.EventRecorder] that records events in memory.
+type spyRecorder struct {
+	events []recordedEvent
+}
+
+var _ events.EventRecorder = &spyRecorder{}
+
+func (s *spyRecorder) Eventf(
+	regarding, related runtime.Object, eventtype, reason, action, note string, args ...any,
+) {
+	s.events = append(s.events, recordedEvent{
+		regarding: regarding,
+		related:   related,
+		eventType: eventtype,
+		reason:    reason,
+		action:    action,
+		note:      fmt.Sprintf(note, args...),
+	})
+}
 
 func Test_RecordResourceOperationEvent(t *testing.T) {
 	cases := []struct {
@@ -22,6 +56,7 @@ func Test_RecordResourceOperationEvent(t *testing.T) {
 		operation       concepts.ConvergingOperation
 		keyValuePairs   []string
 		expectedReason  string
+		expectedAction  string
 		expectedMessage string
 		expectNoEvent   bool
 	}{
@@ -36,6 +71,7 @@ func Test_RecordResourceOperationEvent(t *testing.T) {
 			operation:       concepts.ConvergingOperationCreated,
 			keyValuePairs:   []string{},
 			expectedReason:  "CreatedServiceAccount",
+			expectedAction:  "Create",
 			expectedMessage: "Created ServiceAccount 'test-service-account'",
 		},
 		{
@@ -49,6 +85,7 @@ func Test_RecordResourceOperationEvent(t *testing.T) {
 			operation:       concepts.ConvergingOperationUpdated,
 			keyValuePairs:   []string{"foo=bar"},
 			expectedReason:  "UpdatedDeployment",
+			expectedAction:  "Update",
 			expectedMessage: "Updated Deployment 'test-deployment' (foo=bar)",
 		},
 		{
@@ -78,6 +115,7 @@ func Test_RecordResourceOperationEvent(t *testing.T) {
 			operation:       concepts.ConvergingOperationUpdated,
 			keyValuePairs:   []string{"foo=bar"},
 			expectedReason:  "UpdatedXRole",
+			expectedAction:  "Update",
 			expectedMessage: "Updated XRole 'test-xrole' (foo=bar)",
 		},
 		{
@@ -93,6 +131,7 @@ func Test_RecordResourceOperationEvent(t *testing.T) {
 			operation:       concepts.ConvergingOperationUpdated,
 			keyValuePairs:   []string{"foo=bar"},
 			expectedReason:  "UpdatedXRoleValue",
+			expectedAction:  "Update",
 			expectedMessage: "Updated XRoleValue 'test-xrole-value' (foo=bar)",
 		},
 		{
@@ -110,6 +149,7 @@ func Test_RecordResourceOperationEvent(t *testing.T) {
 			operation:       concepts.ConvergingOperationUpdated,
 			keyValuePairs:   []string{},
 			expectedReason:  "UpdatedServiceAccount",
+			expectedAction:  "Update",
 			expectedMessage: "Updated ServiceAccount 'test-nested-sa'",
 		},
 		{
@@ -126,6 +166,7 @@ func Test_RecordResourceOperationEvent(t *testing.T) {
 			operation:       concepts.ConvergingOperationUpdated,
 			keyValuePairs:   []string{},
 			expectedReason:  "UpdatedXRoleNested",
+			expectedAction:  "Update",
 			expectedMessage: "Updated XRoleNested 'test-xrole-nested'",
 		},
 		{
@@ -139,6 +180,7 @@ func Test_RecordResourceOperationEvent(t *testing.T) {
 			operation:       concepts.ConvergingOperationUpdated,
 			keyValuePairs:   []string{"progress=50%", "template=%s"},
 			expectedReason:  "UpdatedDeployment",
+			expectedAction:  "Update",
 			expectedMessage: "Updated Deployment 'test-deployment' (progress=50%, template=%s)",
 		},
 		{
@@ -152,35 +194,30 @@ func Test_RecordResourceOperationEvent(t *testing.T) {
 			operation:       concepts.ConvergingOperation("Unknown"),
 			keyValuePairs:   []string{},
 			expectedReason:  "UnchangedService",
+			expectedAction:  "Unchanged",
 			expectedMessage: "Service 'test-service' left unchanged",
 		},
 	}
 
-	recorder := record.NewFakeRecorder(1)
-
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			recorder := &spyRecorder{}
+
 			RecordApplyOperationEvent(recorder, tc.operation, tc.object, tc.owner, tc.keyValuePairs...)
 
 			if tc.expectNoEvent {
-				select {
-				case <-recorder.Events:
-					t.Errorf("Expecting no event")
-				default:
-					// all good
-				}
-			} else {
-				select {
-				case event := <-recorder.Events:
-					fields := strings.SplitN(event, " ", 3)
-					assert.Len(t, fields, 3)
-					assert.Equal(t, "Normal", fields[0])
-					assert.Equal(t, tc.expectedReason, fields[1])
-					assert.Equal(t, tc.expectedMessage, fields[2])
-				default:
-					t.Errorf("Missing event")
-				}
+				assert.Empty(t, recorder.events, "expecting no event")
+				return
 			}
+
+			require.Len(t, recorder.events, 1)
+			event := recorder.events[0]
+			assert.Equal(t, tc.owner, event.regarding, "event is recorded on the owner")
+			assert.Equal(t, tc.object, event.related, "applied object is attached as the related object")
+			assert.Equal(t, corev1.EventTypeNormal, event.eventType)
+			assert.Equal(t, tc.expectedReason, event.reason)
+			assert.Equal(t, tc.expectedAction, event.action)
+			assert.Equal(t, tc.expectedMessage, event.note)
 		})
 	}
 }

--- a/plugin/skills/building-components/SKILL.md
+++ b/plugin/skills/building-components/SKILL.md
@@ -183,9 +183,9 @@ that are not "a value exists", such as a status phase reaching a specific value.
 are evaluated first, and the custom guard is consulted only once every guarded cell is set.
 
 `ReconcileContext` carries everything a reconcile pass needs: `Client`, `Scheme`, `EventRecorder` (an
-`events.EventRecorder`, obtained from the manager with `GetEventRecorder(name)`), an optional `Metrics` recorder, and
-`Owner` (the CRD instance that owns the component). Build one per reconcile from your controller and pass it into
-`comp.Reconcile(ctx, recCtx)`.
+`events.EventRecorder`, obtained from the manager with `GetEventRecorder(name)` on controller-runtime v0.23 and later,
+or built from client-go on v0.22.x), an optional `Metrics` recorder, and `Owner` (the CRD instance that owns the
+component). Build one per reconcile from your controller and pass it into `comp.Reconcile(ctx, recCtx)`.
 
 `Component.Reconcile` mutates the owner's status conditions only in memory. The controller persists them by calling
 `component.FlushStatus(ctx, recCtx)` once per reconcile, typically deferred so conditions set on error paths are still

--- a/plugin/skills/building-components/SKILL.md
+++ b/plugin/skills/building-components/SKILL.md
@@ -183,8 +183,8 @@ that are not "a value exists", such as a status phase reaching a specific value.
 are evaluated first, and the custom guard is consulted only once every guarded cell is set.
 
 `ReconcileContext` carries everything a reconcile pass needs: `Client`, `Scheme`, `EventRecorder` (an
-`events.EventRecorder`, obtained from the manager with `GetEventRecorder`), an optional `Metrics` recorder, and `Owner`
-(the CRD instance that owns the component). Build one per reconcile from your controller and pass it into
+`events.EventRecorder`, obtained from the manager with `GetEventRecorder(name)`), an optional `Metrics` recorder, and
+`Owner` (the CRD instance that owns the component). Build one per reconcile from your controller and pass it into
 `comp.Reconcile(ctx, recCtx)`.
 
 `Component.Reconcile` mutates the owner's status conditions only in memory. The controller persists them by calling

--- a/plugin/skills/building-components/SKILL.md
+++ b/plugin/skills/building-components/SKILL.md
@@ -182,9 +182,10 @@ the resource's object and returns a `concepts.GuardStatusWithReason` from arbitr
 that are not "a value exists", such as a status phase reaching a specific value. A resource may use both: data guards
 are evaluated first, and the custom guard is consulted only once every guarded cell is set.
 
-`ReconcileContext` carries everything a reconcile pass needs: `Client`, `Scheme`, `Recorder`, an optional `Metrics`
-recorder, and `Owner` (the CRD instance that owns the component). Build one per reconcile from your controller and pass
-it into `comp.Reconcile(ctx, recCtx)`.
+`ReconcileContext` carries everything a reconcile pass needs: `Client`, `Scheme`, `EventRecorder` (an
+`events.EventRecorder`, obtained from the manager with `GetEventRecorder`), an optional `Metrics` recorder, and `Owner`
+(the CRD instance that owns the component). Build one per reconcile from your controller and pass it into
+`comp.Reconcile(ctx, recCtx)`.
 
 `Component.Reconcile` mutates the owner's status conditions only in memory. The controller persists them by calling
 `component.FlushStatus(ctx, recCtx)` once per reconcile, typically deferred so conditions set on error paths are still

--- a/plugin/skills/building-components/references/component.md
+++ b/plugin/skills/building-components/references/component.md
@@ -508,6 +508,10 @@ optional; when set, the framework records Prometheus metrics for every condition
 recorder from [go-crd-condition-metrics](https://github.com/sourcehawk/go-crd-condition-metrics). Leave it `nil` to opt
 out.
 
+`EventRecorder` takes a `k8s.io/client-go/tools/events.EventRecorder`. The manager accessor that returns one,
+`GetEventRecorder(name)`, was added in controller-runtime v0.23; on v0.22.x, build the recorder from client-go instead,
+as described in [Compatibility](compatibility.md).
+
 ## Persisting Status with FlushStatus
 
 `Component.Reconcile` only mutates the owner's status conditions in memory. The controller persists them by calling

--- a/plugin/skills/building-components/references/component.md
+++ b/plugin/skills/building-components/references/component.md
@@ -493,11 +493,11 @@ component can ever be suspended.
 
 ```go
 recCtx := component.ReconcileContext{
-    Client:   r.Client,    // sigs.k8s.io/controller-runtime/pkg/client
-    Scheme:   r.Scheme,    // *runtime.Scheme
-    Recorder: r.Recorder,  // record.EventRecorder
-    Metrics:  r.Metrics,   // component.Recorder (condition metrics), optional
-    Owner:    owner,       // the CRD that owns this component
+    Client:        r.Client,        // sigs.k8s.io/controller-runtime/pkg/client
+    Scheme:        r.Scheme,        // *runtime.Scheme
+    EventRecorder: r.EventRecorder, // events.EventRecorder, from manager.GetEventRecorder
+    Metrics:       r.Metrics,       // component.MetricsRecorder (condition metrics), optional
+    Owner:         owner,           // the CRD that owns this component
 }
 
 err = comp.Reconcile(ctx, recCtx)
@@ -522,11 +522,11 @@ func (r *WebAppReconciler) Reconcile(ctx context.Context, req reconcile.Request)
     }
 
     recCtx := component.ReconcileContext{
-        Client:   r.Client,
-        Scheme:   r.Scheme,
-        Recorder: r.Recorder,
-        Metrics:  r.Metrics,
-        Owner:    owner,
+        Client:        r.Client,
+        Scheme:        r.Scheme,
+        EventRecorder: r.EventRecorder,
+        Metrics:       r.Metrics,
+        Owner:         owner,
     }
     defer func() {
         if flushErr := component.FlushStatus(ctx, recCtx); flushErr != nil && err == nil {

--- a/plugin/skills/building-components/references/component.md
+++ b/plugin/skills/building-components/references/component.md
@@ -495,7 +495,7 @@ component can ever be suspended.
 recCtx := component.ReconcileContext{
     Client:        r.Client,        // sigs.k8s.io/controller-runtime/pkg/client
     Scheme:        r.Scheme,        // *runtime.Scheme
-    EventRecorder: r.EventRecorder, // events.EventRecorder, from manager.GetEventRecorder
+    EventRecorder: r.EventRecorder, // events.EventRecorder, from manager.GetEventRecorder(name)
     Metrics:       r.Metrics,       // component.MetricsRecorder (condition metrics), optional
     Owner:         owner,           // the CRD that owns this component
 }

--- a/plugin/skills/structuring-operators/references/compatibility.md
+++ b/plugin/skills/structuring-operators/references/compatibility.md
@@ -24,6 +24,20 @@ The framework is tested against the following version combinations:
 
 **Primary** is the version combination used in `go.mod` and in the main CI pipeline.
 
+!!! note "Obtaining an event recorder on controller-runtime v0.22"
+
+    `ReconcileContext.EventRecorder` takes a `k8s.io/client-go/tools/events.EventRecorder`, which is a client-go type
+    available in every `k8s.io/*` version in the matrix. The manager accessor that returns one,
+    `manager.GetEventRecorder(name)`, was added in controller-runtime v0.23. On v0.22.x, build the recorder from
+    client-go directly instead:
+
+    ```go
+    broadcaster := events.NewEventBroadcasterAdapter(clientset)
+    recorder := broadcaster.NewRecorder("webapp-controller")
+    ```
+
+    The framework compiles and tests unchanged against v0.22.x; only the way a consumer obtains the recorder differs.
+
 **Tested** combinations are verified weekly by the compatibility CI workflow. They are fully supported: bugs reported
 against a Tested combination are treated as bugs in the framework, not as unsupported configurations. The distinction
 from Primary is operational only (Primary is tested on every commit; Tested combinations run on a weekly schedule).

--- a/plugin/skills/structuring-operators/references/guidelines.md
+++ b/plugin/skills/structuring-operators/references/guidelines.md
@@ -143,11 +143,11 @@ func (r *WebAppReconciler) Reconcile(ctx context.Context, req reconcile.Request)
     }
 
     recCtx := component.ReconcileContext{
-        Client:   r.Client,
-        Scheme:   r.Scheme,
-        Recorder: r.Recorder,
-        Metrics:  r.Metrics,
-        Owner:    app,
+        Client:        r.Client,
+        Scheme:        r.Scheme,
+        EventRecorder: r.EventRecorder,
+        Metrics:       r.Metrics,
+        Owner:         app,
     }
     // Persist all staged conditions exactly once, even on the error path.
     defer func() {


### PR DESCRIPTION
## Description

`ReconcileContext.Recorder` took a `record.EventRecorder`, so every consumer had to obtain
one through `manager.GetEventRecorderFor`, which controller-runtime deprecated in v0.23 in
favour of `GetEventRecorder`. This retypes the field to `k8s.io/client-go/tools/events.EventRecorder`
and fills in the two fields the new API adds, so recorded events now name the resource that was
acted on and the verb that was applied to it. It is a breaking change: every consumer updates
the field name and the value it assigns, and consumers pinned to controller-runtime v0.22.x have
to build the recorder from client-go directly because the manager accessor does not exist there yet.

## Changes

- `ReconcileContext.Recorder record.EventRecorder` becomes `ReconcileContext.EventRecorder events.EventRecorder`.
- Every recorded event now carries a `related` object (the resource the component acted on) and an
  `action`: `Create` / `Update` on apply, `Delete` on deletion and suspension-deletion, `Orphan` on
  owner-reference release. `regarding` stays the owner, and reasons and message text are unchanged,
  so alerting that matches on reason keeps working.
- Fixes a pre-existing bug in `orphanResources`, surfaced while attaching the released object to the
  event: `removed` was tracked outside the `RetryOnConflict` closure and reset only after a successful
  read, so an attempt that conflicted on update leaked that flag into the next attempt. If the object
  was deleted in between, the retry returned early on NotFound and a `ResourceOrphaned` event was still
  recorded for an object that was never orphaned. Each attempt now resets its own state.
- `component.Recorder` is renamed to `component.MetricsRecorder`, so it no longer shares a name with
  the event recorder field it sits beside.
- `recording.RecordApplyOperationEvent` takes an `events.EventRecorder`. It passes the composed
  message as a `%s` argument rather than as the format string, because the new API always runs the
  note through `fmt.Sprintf` and the old `Event` call did not format at all.
- `GetEventRecorder(name)` only exists from controller-runtime v0.23, and v0.22.x is a Tested row in
  the matrix. `docs/compatibility.md` documents the `events.NewEventBroadcasterAdapter` fallback, and
  the getting-started table, the component reference, and the plugin skill all name the version floor
  rather than handing out an accessor a supported version lacks.
- Fixes an unrelated flake in the orphan e2e spec, hit while validating the change: it created two
  ConfigMaps and read them back with a single `Expect` through the manager's cached client, which
  fails whenever the informer cache is cold. Both precondition reads now poll through the
  `Eventually`-friendly helper the file already documents for that case.
- All five examples, the e2e framework reconcilers, and the affected docs are migrated.

## Challenges

Two properties of the new recorder shaped the implementation. Attaching a `related` object is safe
even when its type is not registered in the recorder's scheme: client-go logs the failed reference at
V(9) and still emits the event, whereas a `regarding` object that cannot be referenced drops the event
entirely, so nothing here can silence an event that used to fire. And `events.FakeRecorder` formats
events as `"<type> <reason> <note>"`, discarding both `related` and `action`, so it cannot verify the
fields this PR adds. The tests use a small spy recorder instead of the client-go fake wherever those
fields are asserted.

## Related

Event reasons and actions are inline string literals, matching how reasons were already written.
Exporting them as constants so consumers can match on them is left as a follow-up.

## Testing

`make all` passes (unit tests, envtest, golangci-lint, formatting, examples build), and the full CI
suite is green, E2E included.

New unit tests assert `regarding`, `related`, `eventType`, `reason`, and `action` at every emit site.
The delete and orphan events had no assertions at all before, including the negative cases (no event when
the resource is already gone, none when the owner reference was already absent). The orphan retry race
has its own regression test driving a mock client through conflict-then-NotFound; it was verified to fail
without the fix. The existing case covering percent signs in `messageKeyValuePairs` guards the `%s`
formatting change.

The e2e cache flake could not be reproduced locally even with the spec focused for a cold cache, since
the local cluster outruns the CI runner. That fix rests on the mechanism, a cached read-after-write, and
on CI going green rather than on a local reproduction.

The controller-runtime versions in the compatibility matrix were checked directly: `GetEventRecorder`
is present in v0.23.0 and v0.24.0 and absent in v0.22.0. The framework itself compiles and tests against
all three, since it depends only on the client-go type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)