### PR TITLE
feat(component): aggregate component conditions into one owner condition

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -446,6 +446,68 @@ A resource registered with [`component.Auxiliary()`](#resource-registration-opti
 health to this aggregation. A blocked guard on an auxiliary resource still contributes, because a blocked guard halts
 the whole pipeline.
 
+### Aggregating components into one owner condition
+
+A controller that runs several components usually needs one condition for all of them. `component.Aggregate` derives
+that aggregate condition from the component conditions already on the owner:
+
+```go
+func Aggregate(conditionType ConditionType, owner OperatorCRD, comps ...*Component) Condition
+```
+
+The controller stages the result on the owner like any other condition:
+
+```go
+ready := component.Aggregate("Ready", owner, brokerComponent, gatewayComponent)
+meta.SetStatusCondition(owner.GetStatusConditions(), metav1.Condition(ready))
+```
+
+Two separate decisions produce the result.
+
+**Truth by unanimity.** The aggregate condition status is `True` if and only if every component condition is `True`.
+Priority never decides `True` or `False`.
+
+**Reason by priority.** The reason and message come from the governing component. If any component condition is not
+`True`, the governing component is the one with the highest `Status.Priority()` among those. If all of them are `True`,
+it is the one with the highest priority among all of them. Argument order breaks ties, so the result is deterministic.
+
+The two decisions must stay separate. A rule that derives truth from priority reports `True`/`Suspended` for an owner
+with a failing component. `Suspended` has priority 15 and maps to condition status `True`, and `AliveFailing` has
+priority 13 and maps to `False`. Unanimity decides whether every component is in its expected state. Priority decides
+which component the reader must look at first.
+
+`Aggregate` reads each component condition through `Component.GetCondition`. For a component that never reconciled, that
+method returns a synthetic `Unknown` condition with status `False`. A new custom resource therefore never reports ready.
+The `ObservedGeneration` field takes the generation of the owner.
+
+The message of the aggregate condition has the form `<component name>: <component message>`. It therefore names the
+governing component and keeps the text of that component. If the governing condition has no message, the aggregate
+message is the component name alone.
+
+| Component conditions passed in | Aggregate condition     |
+| ------------------------------ | ----------------------- |
+| all `Healthy`                  | `True`, `Healthy`       |
+| `Healthy` and `AliveFailing`   | `False`, `AliveFailing` |
+| `Suspended` and `AliveFailing` | `False`, `AliveFailing` |
+| all `Suspended`                | `True`, `Suspended`     |
+| `Suspended` and `Healthy`      | `True`, `Suspended`     |
+| `Healthy` and `Disabled`       | `True`, `Disabled`      |
+| one component never reconciled | `False`, `Unknown`      |
+| one component errored          | `False`, `Error`        |
+| no components passed           | `False`, `Unknown`      |
+
+Four properties of the aggregate condition are easy to miss:
+
+- Partial suspension reports `True` with reason `Suspended`. A suspended component is in its expected state and cannot
+  make the aggregate false. An operator that wants owner-level suspension as an explicit state must branch on its own
+  suspend field before it calls `Aggregate`.
+- A component disabled by a feature gate reports `True`/`Disabled` and therefore counts as ready, for the same reason.
+- `Aggregate` looks only at the components that you pass in. If the controller no longer builds a component, the
+  condition of that component stays on the owner. `Aggregate` ignores that stale condition, but users still see it,
+  because [`FlushStatus`](#persisting-status-with-flushstatus) merges conditions by type and never prunes them.
+- The returned `Condition` is a plain struct. A caller that wants different prose can change the message before it
+  stages the condition with `meta.SetStatusCondition`.
+
 ## Grace Period
 
 The grace period defines how long a component may remain in a converging state (`Creating`, `Updating`, `Scaling`)

--- a/docs/component.md
+++ b/docs/component.md
@@ -469,7 +469,8 @@ Priority never decides `True` or `False`.
 
 **Reason by priority.** The reason and message come from the governing component. If any component condition is not
 `True`, the governing component is the one with the highest `Status.Priority()` among those. If all of them are `True`,
-it is the one with the highest priority among all of them. Argument order breaks ties, so the result is deterministic.
+it is the one with the highest priority among all of them. When two component conditions tie on priority, the first
+component passed to `Aggregate` wins, so the result is deterministic.
 
 The two decisions must stay separate. A rule that derives truth from priority reports `True`/`Suspended` for an owner
 with a failing component. `Suspended` has priority 15 and maps to condition status `True`, and `AliveFailing` has

--- a/pkg/component/aggregate.go
+++ b/pkg/component/aggregate.go
@@ -1,0 +1,124 @@
+package component
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Aggregate collapses the conditions of several components into a single
+// owner-level condition of the given type.
+//
+// Two independent decisions produce the result:
+//
+//  1. Truth by unanimity. The returned Status is [metav1.ConditionTrue] if and
+//     only if every component's condition is True. Priority never decides True
+//     or False.
+//  2. Reason by priority. The Reason and Message come from the governing
+//     component: the one with the highest [Status.Priority] among the conditions
+//     whose status is not True, if any exist, otherwise the highest among all of
+//     them. Argument order breaks ties, so the result is deterministic.
+//
+// Keeping the two decisions apart is what makes the result trustworthy. Deriving
+// truth from priority instead would report True with reason Suspended for an
+// owner with a failing component, because [Suspended] has priority 15 and maps to
+// condition status True while [AliveFailing] has priority 13 and maps to False.
+// Unanimity answers "is everything in its expected state", priority answers "what
+// should the reader look at first".
+//
+// The Message names the governing component and carries its message through, in
+// the form "<component name>: <component message>", so the reader knows which
+// component explains the aggregate. If the governing condition carries no
+// message, the component name alone is used.
+//
+// ObservedGeneration is the owner's generation.
+//
+// Each condition is read with [Component.GetCondition], which synthesizes an
+// Unknown condition with status False for a component that has not reconciled
+// yet. A freshly created owner therefore never reports True.
+//
+// Behavior worth knowing before relying on the result:
+//
+//   - Passing no components returns status False with reason [Unknown]. A caller
+//     that aggregates nothing must never report ready.
+//   - Partial suspension reports True with reason [Suspended]. A suspended
+//     component is in its expected state and cannot make the aggregate false. An
+//     operator that wants owner-level suspension as an explicit state branches on
+//     its own suspend field before calling Aggregate.
+//   - A component disabled by a feature gate reports True with reason [Disabled]
+//     and therefore counts as ready, for the same reason.
+//   - Only the components passed in are considered. A component the controller
+//     has stopped building leaves a stale condition on the owner that Aggregate
+//     ignores but users still see, because [FlushStatus] merges conditions by type
+//     and never prunes.
+//
+// The returned [Condition] is a plain struct. A caller that wants different prose
+// can adjust the Message before staging it:
+//
+//	cond := component.Aggregate("Ready", owner, brokerComp, gatewayComp)
+//	meta.SetStatusCondition(owner.GetStatusConditions(), metav1.Condition(cond))
+func Aggregate(conditionType ConditionType, owner OperatorCRD, comps ...*Component) Condition {
+	generation := owner.GetGeneration()
+
+	if len(comps) == 0 {
+		return Condition{
+			Type:               string(conditionType),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(Unknown),
+			Message:            "No components were aggregated.",
+			ObservedGeneration: generation,
+		}
+	}
+
+	var governing *Component
+	var governingCondition Condition
+	unanimous := true
+
+	for _, comp := range comps {
+		cond := comp.GetCondition(owner)
+
+		if cond.Status != metav1.ConditionTrue {
+			unanimous = false
+		}
+
+		if governing == nil || supersedes(cond, governingCondition) {
+			governing, governingCondition = comp, cond
+		}
+	}
+
+	status := metav1.ConditionFalse
+	if unanimous {
+		status = metav1.ConditionTrue
+	}
+
+	return Condition{
+		Type:               string(conditionType),
+		Status:             status,
+		Reason:             governingCondition.Reason,
+		Message:            aggregateMessage(governing.GetName(), governingCondition.Message),
+		ObservedGeneration: generation,
+	}
+}
+
+// supersedes reports whether candidate should replace current as the governing
+// condition. A condition whose status is not True always supersedes one that is
+// True, so the reason is drawn from the group that explains why the aggregate is
+// false. Within the same group the higher Status.Priority wins. A tie leaves
+// current in place, which makes argument order the tie-breaker.
+func supersedes(candidate, current Condition) bool {
+	candidateTrue := candidate.Status == metav1.ConditionTrue
+	currentTrue := current.Status == metav1.ConditionTrue
+
+	if candidateTrue != currentTrue {
+		return currentTrue
+	}
+
+	return candidate.ComponentStatus().Priority() > current.ComponentStatus().Priority()
+}
+
+// aggregateMessage renders the aggregate message from the governing component's
+// name and message. A governing condition without a message reduces to the name.
+func aggregateMessage(name, message string) string {
+	if message == "" {
+		return name
+	}
+	return name + ": " + message
+}

--- a/pkg/component/aggregate.go
+++ b/pkg/component/aggregate.go
@@ -32,6 +32,9 @@ import (
 //
 // ObservedGeneration is the owner's generation.
 //
+// Every component in comps must be non-nil; a nil component is a programming
+// error.
+//
 // Each condition is read with [Component.GetCondition], which synthesizes an
 // Unknown condition with status False for a component that has not reconciled
 // yet. A freshly created owner therefore never reports True.

--- a/pkg/component/aggregate.go
+++ b/pkg/component/aggregate.go
@@ -15,7 +15,8 @@ import (
 //  2. Reason by priority. The Reason and Message come from the governing
 //     component: the one with the highest [Status.Priority] among the conditions
 //     whose status is not True, if any exist, otherwise the highest among all of
-//     them. Argument order breaks ties, so the result is deterministic.
+//     them. When two candidates tie on priority, the first component passed wins,
+//     so the result is deterministic.
 //
 // Keeping the two decisions apart is what makes the result trustworthy. Deriving
 // truth from priority instead would report True with reason Suspended for an
@@ -102,7 +103,7 @@ func Aggregate(conditionType ConditionType, owner OperatorCRD, comps ...*Compone
 // condition. A condition whose status is not True always supersedes one that is
 // True, so the reason is drawn from the group that explains why the aggregate is
 // false. Within the same group the higher Status.Priority wins. A tie leaves
-// current in place, which makes argument order the tie-breaker.
+// current in place, so the first component passed to Aggregate wins it.
 func supersedes(candidate, current Condition) bool {
 	candidateTrue := candidate.Status == metav1.ConditionTrue
 	currentTrue := current.Status == metav1.ConditionTrue

--- a/pkg/component/aggregate_test.go
+++ b/pkg/component/aggregate_test.go
@@ -1,0 +1,293 @@
+package component_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcehawk/operator-component-framework/pkg/component"
+)
+
+// stagedComponent describes one component participating in an aggregation test:
+// the component to build and, unless absent is set, the condition it has already
+// staged on the owner.
+type stagedComponent struct {
+	name    string
+	absent  bool
+	status  metav1.ConditionStatus
+	reason  component.Status
+	message string
+}
+
+// conditionType returns the condition type owned by the staged component.
+func (s stagedComponent) conditionType() component.ConditionType {
+	return component.ConditionType(s.name + "Ready")
+}
+
+// stage builds one component per entry and writes its condition onto a fresh
+// owner at the given generation. Entries marked absent get a component but no
+// condition, which is how a component that has never reconciled looks.
+func stage(t *testing.T, generation int64, staged ...stagedComponent) (*component.MockOperatorCRD, []*component.Component) {
+	t.Helper()
+
+	owner := &component.MockOperatorCRD{}
+	owner.Generation = generation
+
+	comps := make([]*component.Component, 0, len(staged))
+	for _, s := range staged {
+		comp, err := component.NewComponentBuilder().
+			WithName(s.name).
+			WithConditionType(s.conditionType()).
+			Build()
+		require.NoError(t, err)
+		comps = append(comps, comp)
+
+		if s.absent {
+			continue
+		}
+
+		meta.SetStatusCondition(owner.GetStatusConditions(), metav1.Condition{
+			Type:    string(s.conditionType()),
+			Status:  s.status,
+			Reason:  string(s.reason),
+			Message: s.message,
+		})
+	}
+
+	return owner, comps
+}
+
+func TestAggregate(t *testing.T) {
+	const aggregateType = component.ConditionType("Ready")
+
+	healthy := func(name string) stagedComponent {
+		return stagedComponent{
+			name: name, status: metav1.ConditionTrue,
+			reason: component.Healthy, message: "Component is healthy.",
+		}
+	}
+	suspended := func(name string) stagedComponent {
+		return stagedComponent{
+			name: name, status: metav1.ConditionTrue,
+			reason: component.Suspended, message: "Component is suspended.",
+		}
+	}
+	disabled := func(name string) stagedComponent {
+		return stagedComponent{
+			name: name, status: metav1.ConditionTrue,
+			reason: component.Disabled, message: "Component is disabled.",
+		}
+	}
+	failing := func(name, message string) stagedComponent {
+		return stagedComponent{
+			name: name, status: metav1.ConditionFalse,
+			reason: component.AliveFailing, message: message,
+		}
+	}
+
+	tests := []struct {
+		name     string
+		staged   []stagedComponent
+		expected component.Condition
+	}{
+		{
+			name:   "all components healthy aggregates to True with reason Healthy",
+			staged: []stagedComponent{healthy("broker"), healthy("gateway")},
+			expected: component.Condition{
+				Status:  metav1.ConditionTrue,
+				Reason:  string(component.Healthy),
+				Message: "broker: Component is healthy.",
+			},
+		},
+		{
+			name:   "a failing component makes a healthy aggregate False",
+			staged: []stagedComponent{healthy("broker"), failing("gateway", "Pods are crash looping.")},
+			expected: component.Condition{
+				Status:  metav1.ConditionFalse,
+				Reason:  string(component.AliveFailing),
+				Message: "gateway: Pods are crash looping.",
+			},
+		},
+		{
+			name:   "a failing component outranks a suspended one despite lower priority",
+			staged: []stagedComponent{suspended("broker"), failing("gateway", "Pods are crash looping.")},
+			expected: component.Condition{
+				Status:  metav1.ConditionFalse,
+				Reason:  string(component.AliveFailing),
+				Message: "gateway: Pods are crash looping.",
+			},
+		},
+		{
+			name:   "all components suspended aggregates to True with reason Suspended",
+			staged: []stagedComponent{suspended("broker"), suspended("gateway")},
+			expected: component.Condition{
+				Status:  metav1.ConditionTrue,
+				Reason:  string(component.Suspended),
+				Message: "broker: Component is suspended.",
+			},
+		},
+		{
+			name:   "a suspended component governs the reason of an otherwise healthy aggregate",
+			staged: []stagedComponent{suspended("broker"), healthy("gateway")},
+			expected: component.Condition{
+				Status:  metav1.ConditionTrue,
+				Reason:  string(component.Suspended),
+				Message: "broker: Component is suspended.",
+			},
+		},
+		{
+			name:   "priority not argument order governs the reason within the True group",
+			staged: []stagedComponent{healthy("broker"), suspended("gateway")},
+			expected: component.Condition{
+				Status:  metav1.ConditionTrue,
+				Reason:  string(component.Suspended),
+				Message: "gateway: Component is suspended.",
+			},
+		},
+		{
+			name:   "a disabled component governs the reason and stays True",
+			staged: []stagedComponent{healthy("broker"), disabled("gateway")},
+			expected: component.Condition{
+				Status:  metav1.ConditionTrue,
+				Reason:  string(component.Disabled),
+				Message: "gateway: Component is disabled.",
+			},
+		},
+		{
+			name:   "a component that has never reconciled makes the aggregate False and Unknown",
+			staged: []stagedComponent{healthy("broker"), {name: "gateway", absent: true}},
+			expected: component.Condition{
+				Status:  metav1.ConditionFalse,
+				Reason:  string(component.Unknown),
+				Message: "gateway: Component has not been reconciled yet.",
+			},
+		},
+		{
+			name: "an errored component governs the reason",
+			staged: []stagedComponent{
+				healthy("broker"),
+				{
+					name: "gateway", status: metav1.ConditionFalse,
+					reason: component.Error, message: "failed to apply Deployment.",
+				},
+			},
+			expected: component.Condition{
+				Status:  metav1.ConditionFalse,
+				Reason:  string(component.Error),
+				Message: "gateway: failed to apply Deployment.",
+			},
+		},
+		{
+			name:   "no components aggregates to False with reason Unknown",
+			staged: nil,
+			expected: component.Condition{
+				Status:  metav1.ConditionFalse,
+				Reason:  string(component.Unknown),
+				Message: "No components were aggregated.",
+			},
+		},
+		{
+			name:   "argument order breaks a priority tie within the non-True group",
+			staged: []stagedComponent{failing("broker", "Broker is down."), failing("gateway", "Gateway is down.")},
+			expected: component.Condition{
+				Status:  metav1.ConditionFalse,
+				Reason:  string(component.AliveFailing),
+				Message: "broker: Broker is down.",
+			},
+		},
+		{
+			name:   "argument order breaks a priority tie within the True group",
+			staged: []stagedComponent{suspended("broker"), suspended("gateway"), healthy("worker")},
+			expected: component.Condition{
+				Status:  metav1.ConditionTrue,
+				Reason:  string(component.Suspended),
+				Message: "broker: Component is suspended.",
+			},
+		},
+		{
+			name:   "a single healthy component aggregates to True",
+			staged: []stagedComponent{healthy("broker")},
+			expected: component.Condition{
+				Status:  metav1.ConditionTrue,
+				Reason:  string(component.Healthy),
+				Message: "broker: Component is healthy.",
+			},
+		},
+		{
+			name: "a single converging component aggregates to False",
+			staged: []stagedComponent{{
+				name: "broker", status: metav1.ConditionFalse,
+				reason: component.AliveCreating, message: "Deployment is being created.",
+			}},
+			expected: component.Condition{
+				Status:  metav1.ConditionFalse,
+				Reason:  string(component.AliveCreating),
+				Message: "broker: Deployment is being created.",
+			},
+		},
+		{
+			name: "a governing condition without a message reduces to the component name",
+			staged: []stagedComponent{{
+				name: "broker", status: metav1.ConditionFalse, reason: component.AliveFailing,
+			}},
+			expected: component.Condition{
+				Status:  metav1.ConditionFalse,
+				Reason:  string(component.AliveFailing),
+				Message: "broker",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, comps := stage(t, 3, tt.staged...)
+
+			got := component.Aggregate(aggregateType, owner, comps...)
+
+			assert.Equal(t, string(aggregateType), got.Type)
+			assert.Equal(t, tt.expected.Status, got.Status)
+			assert.Equal(t, tt.expected.Reason, got.Reason)
+			assert.Equal(t, tt.expected.Message, got.Message)
+			assert.Equal(t, int64(3), got.ObservedGeneration)
+		})
+	}
+}
+
+func TestAggregateObservedGenerationTracksOwner(t *testing.T) {
+	owner, comps := stage(t, 9, stagedComponent{
+		name: "broker", status: metav1.ConditionTrue,
+		reason: component.Healthy, message: "Component is healthy.",
+	})
+
+	assert.Equal(t, int64(9), component.Aggregate("Ready", owner, comps...).ObservedGeneration)
+
+	owner.Generation = 10
+	assert.Equal(t, int64(10), component.Aggregate("Ready", owner, comps...).ObservedGeneration)
+}
+
+func TestAggregateWithoutComponentsTracksOwnerGeneration(t *testing.T) {
+	owner, _ := stage(t, 4)
+
+	got := component.Aggregate("Ready", owner)
+
+	assert.Equal(t, int64(4), got.ObservedGeneration)
+	assert.Equal(t, metav1.ConditionFalse, got.Status)
+}
+
+func TestAggregateResultIsStageable(t *testing.T) {
+	owner, comps := stage(t, 1, stagedComponent{
+		name: "broker", status: metav1.ConditionTrue,
+		reason: component.Healthy, message: "Component is healthy.",
+	})
+
+	got := component.Aggregate("Ready", owner, comps...)
+	meta.SetStatusCondition(owner.GetStatusConditions(), metav1.Condition(got))
+
+	staged := meta.FindStatusCondition(*owner.GetStatusConditions(), "Ready")
+	require.NotNil(t, staged)
+	assert.Equal(t, metav1.ConditionTrue, staged.Status)
+	assert.Equal(t, string(component.Healthy), staged.Reason)
+}

--- a/pkg/component/aggregate_test.go
+++ b/pkg/component/aggregate_test.go
@@ -190,7 +190,7 @@ func TestAggregate(t *testing.T) {
 			},
 		},
 		{
-			name:   "argument order breaks a priority tie within the non-True group",
+			name:   "the first component passed wins a priority tie within the non-True group",
 			staged: []stagedComponent{failing("broker", "Broker is down."), failing("gateway", "Gateway is down.")},
 			expected: component.Condition{
 				Status:  metav1.ConditionFalse,
@@ -199,7 +199,7 @@ func TestAggregate(t *testing.T) {
 			},
 		},
 		{
-			name:   "argument order breaks a priority tie within the True group",
+			name:   "the first component passed wins a priority tie within the True group",
 			staged: []stagedComponent{suspended("broker"), suspended("gateway"), healthy("worker")},
 			expected: component.Condition{
 				Status:  metav1.ConditionTrue,

--- a/plugin/skills/building-components/SKILL.md
+++ b/plugin/skills/building-components/SKILL.md
@@ -3,8 +3,9 @@ name: building-components
 description:
   Use when creating or modifying a component built with the operator-component-framework
   (github.com/sourcehawk/operator-component-framework) - covers the component builder, resource registration, feature
-  gates, prerequisites, the reconciliation lifecycle, conditions and the status model, grace periods, suspension,
-  ReconcileContext, FlushStatus, guards, and declared data cells.
+  gates, prerequisites, the reconciliation lifecycle, conditions and the status model, aggregating component conditions
+  into an owner-level condition, grace periods, suspension, ReconcileContext, FlushStatus, guards, and declared data
+  cells.
 ---
 
 # Building Components
@@ -118,6 +119,16 @@ failing/converging/pending states, then the ready states (`Healthy`, `Operationa
 does.
 
 `Reconcile` only stages the condition on the in-memory owner object; it is not the writer of record to the cluster.
+
+`component.Aggregate(conditionType, owner, comps...)` returns one owner-level condition that collapses the conditions of
+several components. It writes nothing, so the controller stages the returned condition with `meta.SetStatusCondition`
+before `FlushStatus` persists it. The aggregate status is `True` if and only if every component condition is `True`, and
+priority never decides `True` or `False`. The reason and message come from the governing component. If any component
+condition is not `True`, the governing component is the one with the highest `Status.Priority()` among those. If all of
+them are `True`, it is the one with the highest priority among all of them. A rule that derives the status from priority
+instead reports a CR with a failing component as ready, because `Suspended` has priority 15 and condition status `True`
+while `AliveFailing` has priority 13 and condition status `False`. A partly suspended CR therefore reports `True` with
+reason `Suspended`, and a call with no components reports `False` with reason `Unknown`.
 
 ## Grace period and suspension
 

--- a/plugin/skills/building-components/references/component.md
+++ b/plugin/skills/building-components/references/component.md
@@ -446,6 +446,68 @@ A resource registered with [`component.Auxiliary()`](#resource-registration-opti
 health to this aggregation. A blocked guard on an auxiliary resource still contributes, because a blocked guard halts
 the whole pipeline.
 
+### Aggregating components into one owner condition
+
+A controller that runs several components usually needs one condition for all of them. `component.Aggregate` derives
+that aggregate condition from the component conditions already on the owner:
+
+```go
+func Aggregate(conditionType ConditionType, owner OperatorCRD, comps ...*Component) Condition
+```
+
+The controller stages the result on the owner like any other condition:
+
+```go
+ready := component.Aggregate("Ready", owner, brokerComponent, gatewayComponent)
+meta.SetStatusCondition(owner.GetStatusConditions(), metav1.Condition(ready))
+```
+
+Two separate decisions produce the result.
+
+**Truth by unanimity.** The aggregate condition status is `True` if and only if every component condition is `True`.
+Priority never decides `True` or `False`.
+
+**Reason by priority.** The reason and message come from the governing component. If any component condition is not
+`True`, the governing component is the one with the highest `Status.Priority()` among those. If all of them are `True`,
+it is the one with the highest priority among all of them. Argument order breaks ties, so the result is deterministic.
+
+The two decisions must stay separate. A rule that derives truth from priority reports `True`/`Suspended` for an owner
+with a failing component. `Suspended` has priority 15 and maps to condition status `True`, and `AliveFailing` has
+priority 13 and maps to `False`. Unanimity decides whether every component is in its expected state. Priority decides
+which component the reader must look at first.
+
+`Aggregate` reads each component condition through `Component.GetCondition`. For a component that never reconciled, that
+method returns a synthetic `Unknown` condition with status `False`. A new custom resource therefore never reports ready.
+The `ObservedGeneration` field takes the generation of the owner.
+
+The message of the aggregate condition has the form `<component name>: <component message>`. It therefore names the
+governing component and keeps the text of that component. If the governing condition has no message, the aggregate
+message is the component name alone.
+
+| Component conditions passed in | Aggregate condition     |
+| ------------------------------ | ----------------------- |
+| all `Healthy`                  | `True`, `Healthy`       |
+| `Healthy` and `AliveFailing`   | `False`, `AliveFailing` |
+| `Suspended` and `AliveFailing` | `False`, `AliveFailing` |
+| all `Suspended`                | `True`, `Suspended`     |
+| `Suspended` and `Healthy`      | `True`, `Suspended`     |
+| `Healthy` and `Disabled`       | `True`, `Disabled`      |
+| one component never reconciled | `False`, `Unknown`      |
+| one component errored          | `False`, `Error`        |
+| no components passed           | `False`, `Unknown`      |
+
+Four properties of the aggregate condition are easy to miss:
+
+- Partial suspension reports `True` with reason `Suspended`. A suspended component is in its expected state and cannot
+  make the aggregate false. An operator that wants owner-level suspension as an explicit state must branch on its own
+  suspend field before it calls `Aggregate`.
+- A component disabled by a feature gate reports `True`/`Disabled` and therefore counts as ready, for the same reason.
+- `Aggregate` looks only at the components that you pass in. If the controller no longer builds a component, the
+  condition of that component stays on the owner. `Aggregate` ignores that stale condition, but users still see it,
+  because [`FlushStatus`](#persisting-status-with-flushstatus) merges conditions by type and never prunes them.
+- The returned `Condition` is a plain struct. A caller that wants different prose can change the message before it
+  stages the condition with `meta.SetStatusCondition`.
+
 ## Grace Period
 
 The grace period defines how long a component may remain in a converging state (`Creating`, `Updating`, `Scaling`)

--- a/plugin/skills/building-components/references/component.md
+++ b/plugin/skills/building-components/references/component.md
@@ -469,7 +469,8 @@ Priority never decides `True` or `False`.
 
 **Reason by priority.** The reason and message come from the governing component. If any component condition is not
 `True`, the governing component is the one with the highest `Status.Priority()` among those. If all of them are `True`,
-it is the one with the highest priority among all of them. Argument order breaks ties, so the result is deterministic.
+it is the one with the highest priority among all of them. When two component conditions tie on priority, the first
+component passed to `Aggregate` wins, so the result is deterministic.
 
 The two decisions must stay separate. A rule that derives truth from priority reports `True`/`Suspended` for an owner
 with a failing component. `Suspended` has priority 15 and maps to condition status `True`, and `AliveFailing` has


### PR DESCRIPTION
## Description

Towards #176

A controller that runs several components has to collapse their conditions into one condition on the owner, and the obvious hand-rolled version is wrong: pick the condition with the highest `Status.Priority()` and take its condition status, and a CR with a failing component reports `True`/`Suspended`, because `Suspended` has priority 15 and maps to condition status `True` while `AliveFailing` has priority 13 and maps to `False`. This PR adds `component.Aggregate`, which makes the two decisions separately. Truth comes from unanimity: the aggregate status is `True` if and only if every component condition is `True`, mirroring `newConvergingStatusCondition`, which decides readiness from `results.healthy()` and only then uses `convergeSummary()` for the reason. The reason and message come from the governing component: the highest `Status.Priority()` among the conditions that are not `True`, otherwise the highest among all of them, with the first component passed winning a tie.

## Changes

- `component.Aggregate(conditionType ConditionType, owner OperatorCRD, comps ...*Component) Condition` returns a plain `Condition` and writes nothing; the caller stages it with `meta.SetStatusCondition`.
- Conditions are read through `Component.GetCondition`, not `meta.FindStatusCondition`, so a component that has never reconciled contributes a synthetic `Unknown` condition with status `False` and a fresh CR never reports ready.
- Passing no components returns status `False` with reason `Unknown`, so a caller that aggregates nothing can never report ready.
- The message has the form `<component name>: <component message>`, so the reader sees which component explains the state.
- `ObservedGeneration` tracks the owner's generation.
- Documentation: a new subsection in `docs/component.md` after the priority table, and a paragraph in the `building-components` skill.

The helper is deliberately unconfigurable and is defined for any number of components, including none. There is no option for how suspension counts: a partly suspended CR reports `True`/`Suspended`, and an operator that wants CR-level suspension as an explicit state branches on its own suspend field before calling `Aggregate`.

## Related

- Builds on the owner-status guidance section in the companion docs PR (branch `docs/owner-status-and-wrapper-guidance`), which currently spells the rule out with a hand-rolled snippet. That snippet is swapped for a call to this helper once both land, so this PR leaves `docs/guidelines.md` untouched.
- The companion docs PR also corrects the pre-existing priority-table row in `docs/component.md` that lists the condition status for `Unknown` as `Unknown`; it is `False`, as `conditionUnknown` in `pkg/component/conditions.go` shows.

## Testing

`make all` passes: `golangci-lint run` reports `0 issues.`, prettier reports `All matched files use Prettier code style!`, and the component suite runs `55 of 55 Specs` green with the package at 95.6% coverage.

The helper is covered by a black-box table test in `pkg/component/aggregate_test.go` that walks the whole behaviour matrix: all healthy, healthy plus failing, suspended plus failing, all suspended, suspended plus healthy, healthy plus disabled, a component that never reconciled, an errored component, and no components at all. It also covers priority beating argument order inside the all-`True` group, the first component passed winning a tie in both groups, single-component aggregation, a governing condition with no message, and `ObservedGeneration` following the owner across generations.

No E2E test: `Aggregate` is a pure function over conditions already on the owner and touches neither the API server nor any resource, so a kind cluster adds no coverage over the unit tests.