### PR TITLE
fix(component): stop reporting Updated on every reconcile for rebuilt resources

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -330,6 +330,13 @@ do this automatically. Managed resources are applied with Server-Side Apply and 
 except where the owner is namespace-scoped and the resource is cluster-scoped (see
 [Cluster-scoped resources](#cluster-scoped-resources)).
 
+Each apply is classified as `Created`, `Updated` or `None` by comparing the live object read before the patch with the
+API server's response to it, ignoring `status`, `managedFields`, `resourceVersion` and `generation`. The classification
+is passed to the resource's status handler as its `concepts.ConvergingOperation` and drives the `Created<Kind>` and
+`Updated<Kind>` events recorded on the owner; `None` records no event. Because it compares live state rather than the
+desired object before and after mutation, a steady-state reconcile reports `None` regardless of whether the operator
+rebuilds its components on every reconcile or keeps them across reconciles.
+
 ### Previewing desired state
 
 `Component.Preview() ([]client.Object, error)` renders the desired state of every managed resource in registration order

--- a/docs/component.md
+++ b/docs/component.md
@@ -330,12 +330,13 @@ do this automatically. Managed resources are applied with Server-Side Apply and 
 except where the owner is namespace-scoped and the resource is cluster-scoped (see
 [Cluster-scoped resources](#cluster-scoped-resources)).
 
-Each apply is classified as `Created`, `Updated` or `None` by comparing the live object read before the patch with the
-API server's response to it, ignoring `status`, `managedFields`, `resourceVersion` and `generation`. The classification
-is passed to the resource's status handler as its `concepts.ConvergingOperation` and drives the `Created<Kind>` and
-`Updated<Kind>` events recorded on the owner; `None` records no event. Because it compares live state rather than the
-desired object before and after mutation, a steady-state reconcile reports `None` regardless of whether the operator
-rebuilds its components on every reconcile or keeps them across reconciles.
+Each apply is classified as `Created`, `Updated` or `None` by comparing the object observed before the patch (read
+through the client, usually the informer cache) with the API server's response to it, ignoring `status`,
+`managedFields`, `resourceVersion` and `generation`. The classification is passed to the resource's status handler as
+its `concepts.ConvergingOperation` and drives the `Created<Kind>` and `Updated<Kind>` events recorded on the owner;
+`None` records no event. Because it compares observed cluster state rather than the desired object before and after
+mutation, a steady-state reconcile reports `None` regardless of whether the operator rebuilds its components on every
+reconcile or keeps them across reconciles.
 
 ### Previewing desired state
 

--- a/docs/custom-resource.md
+++ b/docs/custom-resource.md
@@ -357,6 +357,15 @@ decodes the API server's response into that same object, so those handlers read 
 and `Status` included, and can trust `status.observedGeneration` to tell them whether the object's own controller has
 seen the spec just applied.
 
+The converge and operational status handlers also receive a `concepts.ConvergingOperation` that says what the apply did:
+`Created` when the object did not exist before, `Updated` when the apply changed an existing object, and `None` when it
+left the object as it was. The framework decides this by comparing the live object read before the Server-Side Apply
+with the API server's response, ignoring `status`, `managedFields`, `resourceVersion` and `generation`. It does not
+depend on how the desired object was built, so a wrapper reports `None` on a steady-state reconcile whether the operator
+keeps its resources across reconciles or rebuilds them each pass. Use the operation to distinguish `Creating` from
+`Updating` while `status.observedGeneration` lags, as the example below does; do not use it as a change detector for
+anything the apply cannot see, such as external state.
+
 Three handlers are outside that guarantee. The **guard** runs before the resource is applied, which is its whole
 purpose, so it sees the desired object rather than the server's response. The suspension **mutation** handler takes the
 mutator rather than the object and runs before the patch is sent. The **delete-on-suspend decision** may be consulted

--- a/docs/custom-resource.md
+++ b/docs/custom-resource.md
@@ -359,12 +359,13 @@ seen the spec just applied.
 
 The converge and operational status handlers also receive a `concepts.ConvergingOperation` that says what the apply did:
 `Created` when the object did not exist before, `Updated` when the apply changed an existing object, and `None` when it
-left the object as it was. The framework decides this by comparing the live object read before the Server-Side Apply
-with the API server's response, ignoring `status`, `managedFields`, `resourceVersion` and `generation`. It does not
-depend on how the desired object was built, so a wrapper reports `None` on a steady-state reconcile whether the operator
-keeps its resources across reconciles or rebuilds them each pass. Use the operation to distinguish `Creating` from
-`Updating` while `status.observedGeneration` lags, as the example below does; do not use it as a change detector for
-anything the apply cannot see, such as external state.
+left the object as it was. The framework decides this by comparing the object observed before the Server-Side Apply
+(read through the client, usually the informer cache) with the API server's response, ignoring `status`,
+`managedFields`, `resourceVersion` and `generation`. It does not depend on how the desired object was built, so a
+wrapper reports `None` on a steady-state reconcile whether the operator keeps its resources across reconciles or
+rebuilds them each pass. Use the operation to distinguish `Creating` from `Updating` while `status.observedGeneration`
+lags, as the example below does; do not use it as a change detector for anything the apply cannot see, such as external
+state.
 
 Three handlers are outside that guarantee. The **guard** runs before the resource is applied, which is its whole
 purpose, so it sees the desired object rather than the server's response. The suspension **mutation** handler takes the

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -273,6 +273,46 @@ var _ = Describe("Component Reconciler", func() {
 			Expect(recorder.recordedWithReason("UpdatedConfigMap")).To(HaveLen(1))
 		})
 
+		It("should classify a rebuilt typed CRD object and hand handlers exactly the server response", func() {
+			// Given: a JSON-decoded typed object (CRDs are not served as protobuf,
+			// and JSON decoding into a populated struct keeps fields the response
+			// omits). The desired object carries a status value that a main-resource
+			// apply ignores when the status subresource is enabled, so the server
+			// never echoes it.
+			value := "a"
+			res := &objectOperationRecordingResource{
+				build: func() client.Object {
+					return &MockOperatorCRD{
+						ObjectMeta: metav1.ObjectMeta{Name: "rebuilt-crd", Namespace: namespace},
+						Spec:       MockSpec{Value: value},
+						Status:     MockStatus{ObservedGeneration: 7},
+					}
+				},
+			}
+			comp.reconcileResources = []reconcileEntry{{Resource: res, Options: resourceOptions{ParticipationMode: ParticipationModeRequired}}}
+
+			// When
+			for range 3 {
+				Expect(comp.Reconcile(ctx, recCtx)).To(Succeed())
+			}
+			value = "b"
+			Expect(comp.Reconcile(ctx, recCtx)).To(Succeed())
+
+			// Then: steady state is None, the change is Updated, and the object the
+			// handlers see is the server's response rather than a merge with the
+			// desired object.
+			Expect(res.operations).To(Equal([]concepts.ConvergingOperation{
+				concepts.ConvergingOperationCreated,
+				concepts.ConvergingOperationNone,
+				concepts.ConvergingOperationNone,
+				concepts.ConvergingOperationUpdated,
+			}))
+			applied := res.applied.(*MockOperatorCRD)
+			Expect(applied.Spec.Value).To(Equal("b"))
+			Expect(applied.Status.ObservedGeneration).To(BeZero(), "status set on the desired object is not applied and must not linger")
+			Expect(applied.ResourceVersion).NotTo(BeEmpty())
+		})
+
 		It("should aggregate status across both create and read-only resources", func() {
 			// Given
 			cm1 := &corev1.ConfigMap{

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -232,6 +232,47 @@ var _ = Describe("Component Reconciler", func() {
 			Expect(fetched.OwnerReferences).To(BeEmpty(), "read-only resource should not get an owner reference")
 		})
 
+		It("should report None instead of Updated when a rebuilt desired object is unchanged", func() {
+			// Given: a resource that builds a fresh desired object on every Object() call,
+			// as operators that construct their components in Reconcile do. The owner
+			// reference and mutations are added by the framework on every pass.
+			data := map[string]string{"foo": "bar"}
+			res := &operationRecordingResource{
+				build: func() *corev1.ConfigMap {
+					cm := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "rebuilt-cm", Namespace: namespace},
+						Data:       map[string]string{},
+					}
+					for k, v := range data {
+						cm.Data[k] = v
+					}
+					return cm
+				},
+				mutate: func(cm *corev1.ConfigMap) { cm.Data["feature"] = "enabled" },
+			}
+			comp.reconcileResources = []reconcileEntry{{Resource: res, Options: resourceOptions{ParticipationMode: ParticipationModeRequired}}}
+
+			// When: reconciled repeatedly without a change, then once after a change
+			for range 3 {
+				Expect(comp.Reconcile(ctx, recCtx)).To(Succeed())
+			}
+			data["foo"] = "baz"
+			Expect(comp.Reconcile(ctx, recCtx)).To(Succeed())
+			Expect(comp.Reconcile(ctx, recCtx)).To(Succeed())
+
+			// Then: only the first apply creates and only the changed apply updates
+			Expect(res.operations).To(Equal([]concepts.ConvergingOperation{
+				concepts.ConvergingOperationCreated,
+				concepts.ConvergingOperationNone,
+				concepts.ConvergingOperationNone,
+				concepts.ConvergingOperationUpdated,
+				concepts.ConvergingOperationNone,
+			}))
+			recorder := recCtx.EventRecorder.(*spyRecorder)
+			Expect(recorder.recordedWithReason("CreatedConfigMap")).To(HaveLen(1))
+			Expect(recorder.recordedWithReason("UpdatedConfigMap")).To(HaveLen(1))
+		})
+
 		It("should aggregate status across both create and read-only resources", func() {
 			// Given
 			cm1 := &corev1.ConfigMap{

--- a/pkg/component/concepts/converging.go
+++ b/pkg/component/concepts/converging.go
@@ -6,16 +6,30 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// ConvergingOperation represents the result of a CreateOrUpdate operation on a resource.
-// It provides context to the Alive interface to help determine the ConvergingStatus.
+// ConvergingOperation classifies what the framework's apply did to a resource in
+// the current reconcile. It provides context to the lifecycle interfaces (Alive,
+// Completable, Operational) to help determine the converging status, and it
+// selects the Created/Updated event recorded for the resource.
+//
+// The framework derives it by comparing the live object read before the
+// Server-Side Apply with the API server's response to it, ignoring the status
+// subresource, managedFields, resourceVersion and generation. The classification
+// therefore reflects whether the applied desired state changed the object, not
+// how the desired object was constructed: operators that rebuild their desired
+// objects on every reconcile and operators that keep them across reconciles get
+// the same result.
 type ConvergingOperation string
 
 const (
-	// ConvergingOperationCreated indicates that the resource was newly created.
+	// ConvergingOperationCreated indicates that the resource did not exist before
+	// the apply and was created by it.
 	ConvergingOperationCreated ConvergingOperation = "Created"
-	// ConvergingOperationUpdated indicates that an existing resource was updated.
+	// ConvergingOperationUpdated indicates that the resource existed and the apply
+	// changed it: its labels, annotations, owner references, spec or data differ
+	// from what was live before the apply.
 	ConvergingOperationUpdated ConvergingOperation = "Updated"
-	// ConvergingOperationNone indicates that no changes were made to the resource.
+	// ConvergingOperationNone indicates that the apply left the existing resource
+	// unchanged, or that the resource was only read (read-only resources).
 	ConvergingOperationNone ConvergingOperation = "None"
 )
 

--- a/pkg/component/concepts/converging.go
+++ b/pkg/component/concepts/converging.go
@@ -11,8 +11,9 @@ import (
 // Completable, Operational) to help determine the converging status, and it
 // selects the Created/Updated event recorded for the resource.
 //
-// The framework derives it by comparing the live object read before the
-// Server-Side Apply with the API server's response to it, ignoring the status
+// The framework derives it by comparing the object observed before the
+// Server-Side Apply (read through the client, usually the informer cache) with
+// the API server's response to it, ignoring the status
 // subresource, managedFields, resourceVersion and generation. The classification
 // therefore reflects whether the applied desired state changed the object, not
 // how the desired object was constructed: operators that rebuild their desired
@@ -26,7 +27,7 @@ const (
 	ConvergingOperationCreated ConvergingOperation = "Created"
 	// ConvergingOperationUpdated indicates that the resource existed and the apply
 	// changed it: its labels, annotations, owner references, spec or data differ
-	// from what was live before the apply.
+	// from what was observed before the apply.
 	ConvergingOperationUpdated ConvergingOperation = "Updated"
 	// ConvergingOperationNone indicates that the apply left the existing resource
 	// unchanged, or that the resource was only read (read-only resources).

--- a/pkg/component/create.go
+++ b/pkg/component/create.go
@@ -3,6 +3,7 @@ package component
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/sourcehawk/operator-component-framework/internal/scope"
 	"github.com/sourcehawk/operator-component-framework/pkg/component/concepts"
@@ -35,8 +36,12 @@ func applyResource(
 	}
 
 	// Check if the object already exists (reads from informer cache, not the API server).
+	// The live object is fetched into a zeroed instance rather than a copy of the
+	// desired object: decoding into a pre-populated struct keeps map entries and
+	// fields the response does not mention, which would skew the applied-state
+	// comparison below.
 	var objectExists bool
-	existing := obj.DeepCopyObject().(client.Object)
+	existing := newEmptyObjectLike(obj)
 	if err := rec.Client.Get(ctx, client.ObjectKeyFromObject(obj), existing); err == nil {
 		objectExists = true
 	} else if !apierrors.IsNotFound(err) {
@@ -45,29 +50,12 @@ func applyResource(
 		)
 	}
 
-	// Snapshot the object before mutations for operation detection.
-	// Comparing pre-Mutate vs post-Mutate detects whether the operator's desired
-	// state actually changed, without being affected by status subresource updates
-	// from other controllers (Mutate does not touch status).
-	preMutate := obj.DeepCopyObject()
-
 	// Apply mutations to desired state
 	ownerRefSkipped, err := mutateResource(resource, obj, rec.Owner, rec.Scheme, mapper, skipOwnerRef)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to mutate resource %s: %w", resource.Identity(), err,
 		)
-	}
-
-	// Determine the converging operation before clearing server fields.
-	var convergingOperation concepts.ConvergingOperation
-	switch {
-	case !objectExists:
-		convergingOperation = concepts.ConvergingOperationCreated
-	case !equality.Semantic.DeepEqual(preMutate, obj):
-		convergingOperation = concepts.ConvergingOperationUpdated
-	default:
-		convergingOperation = concepts.ConvergingOperationNone
 	}
 
 	// Prepare the object for SSA by clearing server-populated fields that must not
@@ -90,6 +78,25 @@ func applyResource(
 		return nil, fmt.Errorf(
 			"failed to apply resource %s: %w", resource.Identity(), err,
 		)
+	}
+
+	// Classify the apply by comparing the live object before the patch with the
+	// server's response after it. Comparing the desired object before and after
+	// Mutate would misreport an update on every reconcile for operators that
+	// rebuild their desired objects each pass, because the owner reference and
+	// feature mutations are always added relative to the freshly built object.
+	convergingOperation := concepts.ConvergingOperationCreated
+	if objectExists {
+		changed, err := appliedObjectChanged(existing, obj)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to compare applied state of resource %s: %w", resource.Identity(), err,
+			)
+		}
+		convergingOperation = concepts.ConvergingOperationNone
+		if changed {
+			convergingOperation = concepts.ConvergingOperationUpdated
+		}
 	}
 
 	if ownerRefSkipped && convergingOperation != concepts.ConvergingOperationNone {
@@ -296,6 +303,73 @@ func mutateResource(
 	}
 
 	return false, ctrl.SetControllerReference(owner, obj, scheme)
+}
+
+// newEmptyObjectLike returns a zero-valued object of the same Go type as obj,
+// carrying obj's GroupVersionKind so that unstructured objects remain
+// addressable through the client.
+func newEmptyObjectLike(obj client.Object) client.Object {
+	empty := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(client.Object)
+	empty.GetObjectKind().SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+	return empty
+}
+
+// appliedObjectChanged reports whether a Server-Side Apply changed the object,
+// by comparing the live object read before the patch with the API server's
+// response to it.
+//
+// The comparison ignores fields that change without the desired state changing:
+// the status subresource (written by other controllers), managedFields and
+// resourceVersion (bookkeeping the server touches on any write), generation
+// (derived from the compared content) and TypeMeta (present or absent depending
+// on how the object was decoded). Everything else, including labels,
+// annotations, owner references and the object's spec or data, counts.
+//
+// It does not rely on resourceVersion because concurrent status writes bump it
+// without touching the desired state, and because fake clients bump it on
+// every apply, even a no-op one.
+func appliedObjectChanged(before, after client.Object) (bool, error) {
+	beforeContent, err := comparableContent(before)
+	if err != nil {
+		return false, err
+	}
+	afterContent, err := comparableContent(after)
+	if err != nil {
+		return false, err
+	}
+	return !equality.Semantic.DeepEqual(beforeContent, afterContent), nil
+}
+
+// comparableContent renders an object as an unstructured map with the fields
+// appliedObjectChanged ignores removed. It copies the top-level and metadata
+// maps before deleting keys so the object itself is never mutated (for
+// *unstructured.Unstructured, ToUnstructured returns the object's own content).
+func comparableContent(obj client.Object) (map[string]any, error) {
+	converted, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	content := make(map[string]any, len(converted))
+	for k, v := range converted {
+		content[k] = v
+	}
+	delete(content, "apiVersion")
+	delete(content, "kind")
+	delete(content, "status")
+
+	if rawMetadata, ok := content["metadata"].(map[string]any); ok {
+		metadata := make(map[string]any, len(rawMetadata))
+		for k, v := range rawMetadata {
+			metadata[k] = v
+		}
+		delete(metadata, "managedFields")
+		delete(metadata, "resourceVersion")
+		delete(metadata, "generation")
+		content["metadata"] = metadata
+	}
+
+	return content, nil
 }
 
 // clearServerFields removes metadata fields that the API server populates on

--- a/pkg/component/create.go
+++ b/pkg/component/create.go
@@ -41,7 +41,12 @@ func applyResource(
 	// fields the response does not mention, which would skew the applied-state
 	// comparison below.
 	var objectExists bool
-	existing := newEmptyObjectLike(obj)
+	existing, err := newEmptyObjectLike(obj)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to prepare existence check for resource %s: %w", resource.Identity(), err,
+		)
+	}
 	if err := rec.Client.Get(ctx, client.ObjectKeyFromObject(obj), existing); err == nil {
 		objectExists = true
 	} else if !apierrors.IsNotFound(err) {
@@ -308,11 +313,19 @@ func mutateResource(
 
 // newEmptyObjectLike returns a zero-valued object of the same Go type as obj,
 // carrying obj's GroupVersionKind so that unstructured objects remain
-// addressable through the client.
-func newEmptyObjectLike(obj client.Object) client.Object {
-	empty := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(client.Object)
+// addressable through the client. It returns an error for a nil or non-pointer
+// object, which the client could not decode into anyway.
+func newEmptyObjectLike(obj client.Object) (client.Object, error) {
+	typ := reflect.TypeOf(obj)
+	if typ == nil || typ.Kind() != reflect.Pointer {
+		return nil, fmt.Errorf("object must be a non-nil pointer, got %T", obj)
+	}
+	empty, ok := reflect.New(typ.Elem()).Interface().(client.Object)
+	if !ok {
+		return nil, fmt.Errorf("zero value of %T does not implement client.Object", obj)
+	}
 	empty.GetObjectKind().SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
-	return empty
+	return empty, nil
 }
 
 // appliedObjectChanged reports whether a Server-Side Apply changed the object,

--- a/pkg/component/create.go
+++ b/pkg/component/create.go
@@ -35,7 +35,7 @@ func applyResource(
 		)
 	}
 
-	// Check if the object already exists (reads from informer cache, not the API server).
+	// Check if the object already exists (read through the client, usually the informer cache).
 	// The observed object is fetched into a zeroed instance rather than a copy of
 	// the desired object: decoding into a pre-populated struct keeps map entries and
 	// fields the response does not mention, which would skew the applied-state

--- a/pkg/component/create.go
+++ b/pkg/component/create.go
@@ -37,9 +37,9 @@ func applyResource(
 
 	// Check if the object already exists (read through the client, usually the informer cache).
 	// The observed object is fetched into a zeroed instance rather than a copy of
-	// the desired object: decoding into a pre-populated struct keeps map entries and
-	// fields the response does not mention, which would skew the applied-state
-	// comparison below.
+	// the desired object, so the pre-apply snapshot used by the comparison below
+	// holds only what the client returned and does not rely on the client zeroing
+	// its target before decoding.
 	var objectExists bool
 	existing, err := newEmptyObjectLike(obj)
 	if err != nil {

--- a/pkg/component/create.go
+++ b/pkg/component/create.go
@@ -36,8 +36,8 @@ func applyResource(
 	}
 
 	// Check if the object already exists (reads from informer cache, not the API server).
-	// The live object is fetched into a zeroed instance rather than a copy of the
-	// desired object: decoding into a pre-populated struct keeps map entries and
+	// The observed object is fetched into a zeroed instance rather than a copy of
+	// the desired object: decoding into a pre-populated struct keeps map entries and
 	// fields the response does not mention, which would skew the applied-state
 	// comparison below.
 	var objectExists bool
@@ -80,8 +80,9 @@ func applyResource(
 		)
 	}
 
-	// Classify the apply by comparing the live object before the patch with the
-	// server's response after it. Comparing the desired object before and after
+	// Classify the apply by comparing the object observed before the patch (read
+	// through the client, usually the informer cache) with the server's response
+	// after it. Comparing the desired object before and after
 	// Mutate would misreport an update on every reconcile for operators that
 	// rebuild their desired objects each pass, because the owner reference and
 	// feature mutations are always added relative to the freshly built object.
@@ -315,8 +316,8 @@ func newEmptyObjectLike(obj client.Object) client.Object {
 }
 
 // appliedObjectChanged reports whether a Server-Side Apply changed the object,
-// by comparing the live object read before the patch with the API server's
-// response to it.
+// by comparing the object observed before the patch (read through the client,
+// usually the informer cache) with the API server's response to it.
 //
 // The comparison ignores fields that change without the desired state changing:
 // the status subresource (written by other controllers), managedFields and

--- a/pkg/component/create.go
+++ b/pkg/component/create.go
@@ -316,11 +316,11 @@ func mutateResource(
 // addressable through the client. It returns an error for a nil or non-pointer
 // object, which the client could not decode into anyway.
 func newEmptyObjectLike(obj client.Object) (client.Object, error) {
-	typ := reflect.TypeOf(obj)
-	if typ == nil || typ.Kind() != reflect.Pointer {
+	val := reflect.ValueOf(obj)
+	if !val.IsValid() || val.Kind() != reflect.Pointer || val.IsNil() {
 		return nil, fmt.Errorf("object must be a non-nil pointer, got %T", obj)
 	}
-	empty, ok := reflect.New(typ.Elem()).Interface().(client.Object)
+	empty, ok := reflect.New(val.Type().Elem()).Interface().(client.Object)
 	if !ok {
 		return nil, fmt.Errorf("zero value of %T does not implement client.Object", obj)
 	}

--- a/pkg/component/create_test.go
+++ b/pkg/component/create_test.go
@@ -541,6 +541,38 @@ func TestApplyResource_ConvergingOperation(t *testing.T) {
 	})
 }
 
+func TestNewEmptyObjectLike(t *testing.T) {
+	t.Run("returns a zeroed typed object of the same type", func(t *testing.T) {
+		src := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "ns"},
+			Data:       map[string]string{"k": "v"},
+		}
+		empty, err := newEmptyObjectLike(src)
+		require.NoError(t, err)
+		cm, ok := empty.(*corev1.ConfigMap)
+		require.True(t, ok)
+		assert.Empty(t, cm.Name)
+		assert.Nil(t, cm.Data)
+	})
+
+	t.Run("carries the GVK for unstructured objects", func(t *testing.T) {
+		src := &unstructured.Unstructured{}
+		src.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+		src.SetName("src")
+		empty, err := newEmptyObjectLike(src)
+		require.NoError(t, err)
+		u, ok := empty.(*unstructured.Unstructured)
+		require.True(t, ok)
+		assert.Equal(t, corev1.SchemeGroupVersion.WithKind("ConfigMap"), u.GroupVersionKind())
+		assert.Empty(t, u.GetName())
+	})
+
+	t.Run("rejects a nil object instead of panicking", func(t *testing.T) {
+		_, err := newEmptyObjectLike(nil)
+		require.Error(t, err)
+	})
+}
+
 func TestMutateResource(t *testing.T) {
 	var (
 		scheme    = setupScheme()

--- a/pkg/component/create_test.go
+++ b/pkg/component/create_test.go
@@ -567,8 +567,14 @@ func TestNewEmptyObjectLike(t *testing.T) {
 		assert.Empty(t, u.GetName())
 	})
 
-	t.Run("rejects a nil object instead of panicking", func(t *testing.T) {
+	t.Run("rejects a nil interface instead of panicking", func(t *testing.T) {
 		_, err := newEmptyObjectLike(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects a typed nil pointer instead of panicking", func(t *testing.T) {
+		var cm *corev1.ConfigMap
+		_, err := newEmptyObjectLike(cm)
 		require.Error(t, err)
 	})
 }

--- a/pkg/component/create_test.go
+++ b/pkg/component/create_test.go
@@ -357,31 +357,38 @@ func (r *operationRecordingResource) GraceStatus() (concepts.GraceStatusWithReas
 	return concepts.GraceStatusWithReason{Status: concepts.GraceStatusHealthy}, nil
 }
 
-// unstructuredOperationRecordingResource is the unstructured counterpart of
-// operationRecordingResource.
-type unstructuredOperationRecordingResource struct {
+// objectOperationRecordingResource is the counterpart of
+// operationRecordingResource for any client.Object type.
+type objectOperationRecordingResource struct {
 	build      func() client.Object
 	operations []concepts.ConvergingOperation
+	// applied is the object handed to Mutate. The framework decodes the apply
+	// response into that same object, so after a reconcile it holds what the
+	// server returned.
+	applied client.Object
 }
 
-func (r *unstructuredOperationRecordingResource) Identity() string {
-	return "ConfigMap/operation-recording-unstructured"
+func (r *objectOperationRecordingResource) Identity() string {
+	return "operation-recording-object"
 }
 
-func (r *unstructuredOperationRecordingResource) Object() (client.Object, error) {
+func (r *objectOperationRecordingResource) Object() (client.Object, error) {
 	return r.build(), nil
 }
 
-func (r *unstructuredOperationRecordingResource) Mutate(client.Object) error { return nil }
+func (r *objectOperationRecordingResource) Mutate(obj client.Object) error {
+	r.applied = obj
+	return nil
+}
 
-func (r *unstructuredOperationRecordingResource) ConvergingStatus(
+func (r *objectOperationRecordingResource) ConvergingStatus(
 	op concepts.ConvergingOperation,
 ) (concepts.AliveStatusWithReason, error) {
 	r.operations = append(r.operations, op)
 	return concepts.AliveStatusWithReason{Status: concepts.AliveConvergingStatusHealthy, Reason: "ok"}, nil
 }
 
-func (r *unstructuredOperationRecordingResource) GraceStatus() (concepts.GraceStatusWithReason, error) {
+func (r *objectOperationRecordingResource) GraceStatus() (concepts.GraceStatusWithReason, error) {
 	return concepts.GraceStatusWithReason{Status: concepts.GraceStatusHealthy}, nil
 }
 
@@ -508,7 +515,7 @@ func TestApplyResource_ConvergingOperation(t *testing.T) {
 			require.NoError(t, unstructured.SetNestedField(u.Object, runtime.DeepCopyJSON(data), "data"))
 			return u
 		}
-		res := &unstructuredOperationRecordingResource{build: build}
+		res := &objectOperationRecordingResource{build: build}
 
 		apply(t, rec, res)
 		apply(t, rec, res)

--- a/pkg/component/create_test.go
+++ b/pkg/component/create_test.go
@@ -12,6 +12,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -320,6 +322,222 @@ func TestApplyResources(t *testing.T) {
 		assert.Contains(t, err.Error(), "mutation failed")
 
 		resource.AssertExpectations(t)
+	})
+}
+
+// operationRecordingResource is an Alive resource that builds its desired object
+// from scratch on every Object() call, mirroring operators that rebuild their
+// components on each reconcile. It records the converging operation passed to
+// ConvergingStatus so tests can assert how each apply was classified.
+type operationRecordingResource struct {
+	build      func() *corev1.ConfigMap
+	mutate     func(*corev1.ConfigMap)
+	operations []concepts.ConvergingOperation
+}
+
+func (r *operationRecordingResource) Identity() string { return "ConfigMap/operation-recording" }
+
+func (r *operationRecordingResource) Object() (client.Object, error) { return r.build(), nil }
+
+func (r *operationRecordingResource) Mutate(obj client.Object) error {
+	if r.mutate != nil {
+		r.mutate(obj.(*corev1.ConfigMap))
+	}
+	return nil
+}
+
+func (r *operationRecordingResource) ConvergingStatus(
+	op concepts.ConvergingOperation,
+) (concepts.AliveStatusWithReason, error) {
+	r.operations = append(r.operations, op)
+	return concepts.AliveStatusWithReason{Status: concepts.AliveConvergingStatusHealthy, Reason: "ok"}, nil
+}
+
+func (r *operationRecordingResource) GraceStatus() (concepts.GraceStatusWithReason, error) {
+	return concepts.GraceStatusWithReason{Status: concepts.GraceStatusHealthy}, nil
+}
+
+// unstructuredOperationRecordingResource is the unstructured counterpart of
+// operationRecordingResource.
+type unstructuredOperationRecordingResource struct {
+	build      func() client.Object
+	operations []concepts.ConvergingOperation
+}
+
+func (r *unstructuredOperationRecordingResource) Identity() string {
+	return "ConfigMap/operation-recording-unstructured"
+}
+
+func (r *unstructuredOperationRecordingResource) Object() (client.Object, error) {
+	return r.build(), nil
+}
+
+func (r *unstructuredOperationRecordingResource) Mutate(client.Object) error { return nil }
+
+func (r *unstructuredOperationRecordingResource) ConvergingStatus(
+	op concepts.ConvergingOperation,
+) (concepts.AliveStatusWithReason, error) {
+	r.operations = append(r.operations, op)
+	return concepts.AliveStatusWithReason{Status: concepts.AliveConvergingStatusHealthy, Reason: "ok"}, nil
+}
+
+func (r *unstructuredOperationRecordingResource) GraceStatus() (concepts.GraceStatusWithReason, error) {
+	return concepts.GraceStatusWithReason{Status: concepts.GraceStatusHealthy}, nil
+}
+
+func TestApplyResource_ConvergingOperation(t *testing.T) {
+	const namespace = "test-namespace"
+
+	newEnv := func(t *testing.T) (ReconcileContext, client.Client) {
+		t.Helper()
+		scheme := setupScheme()
+		owner := &MockOperatorCRD{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-owner", Namespace: namespace, UID: "owner-uid"},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner).WithStatusSubresource(owner).Build()
+		return setupReconcileContext(scheme, owner, fakeClient), fakeClient
+	}
+
+	buildConfigMap := func(data map[string]string) func() *corev1.ConfigMap {
+		return func() *corev1.ConfigMap {
+			cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "rebuilt-cm", Namespace: namespace}}
+			for k, v := range data {
+				if cm.Data == nil {
+					cm.Data = map[string]string{}
+				}
+				cm.Data[k] = v
+			}
+			return cm
+		}
+	}
+
+	apply := func(t *testing.T, rec ReconcileContext, res Resource) {
+		t.Helper()
+		_, err := applyResources(t.Context(), rec, []reconcileEntry{{Resource: res}}, "test-component", createTestRESTMapper())
+		require.NoError(t, err)
+	}
+
+	t.Run("reports None when a rebuilt desired object matches what is already applied", func(t *testing.T) {
+		rec, _ := newEnv(t)
+		res := &operationRecordingResource{build: buildConfigMap(map[string]string{"foo": "bar"})}
+
+		apply(t, rec, res)
+		apply(t, rec, res)
+		apply(t, rec, res)
+
+		assert.Equal(t, []concepts.ConvergingOperation{
+			concepts.ConvergingOperationCreated,
+			concepts.ConvergingOperationNone,
+			concepts.ConvergingOperationNone,
+		}, res.operations)
+		assert.Empty(t, rec.EventRecorder.(*spyRecorder).recordedWithReason("UpdatedConfigMap"))
+	})
+
+	t.Run("reports None when feature mutations are re-applied to a rebuilt desired object", func(t *testing.T) {
+		rec, _ := newEnv(t)
+		res := &operationRecordingResource{
+			build:  buildConfigMap(map[string]string{"foo": "bar"}),
+			mutate: func(cm *corev1.ConfigMap) { cm.Data["feature"] = "enabled" },
+		}
+
+		apply(t, rec, res)
+		apply(t, rec, res)
+
+		assert.Equal(t, []concepts.ConvergingOperation{
+			concepts.ConvergingOperationCreated,
+			concepts.ConvergingOperationNone,
+		}, res.operations)
+	})
+
+	t.Run("reports Updated when the rebuilt desired object changes", func(t *testing.T) {
+		rec, _ := newEnv(t)
+		res := &operationRecordingResource{build: buildConfigMap(map[string]string{"foo": "bar"})}
+		apply(t, rec, res)
+
+		res.build = buildConfigMap(map[string]string{"foo": "baz"})
+		apply(t, rec, res)
+		apply(t, rec, res)
+
+		assert.Equal(t, []concepts.ConvergingOperation{
+			concepts.ConvergingOperationCreated,
+			concepts.ConvergingOperationUpdated,
+			concepts.ConvergingOperationNone,
+		}, res.operations)
+		assert.Len(t, rec.EventRecorder.(*spyRecorder).recordedWithReason("UpdatedConfigMap"), 1)
+	})
+
+	t.Run("reports Updated when a feature mutation starts changing the applied object", func(t *testing.T) {
+		rec, _ := newEnv(t)
+		res := &operationRecordingResource{build: buildConfigMap(map[string]string{"foo": "bar"})}
+		apply(t, rec, res)
+
+		res.mutate = func(cm *corev1.ConfigMap) { cm.Data["feature"] = "enabled" }
+		apply(t, rec, res)
+		apply(t, rec, res)
+
+		assert.Equal(t, []concepts.ConvergingOperation{
+			concepts.ConvergingOperationCreated,
+			concepts.ConvergingOperationUpdated,
+			concepts.ConvergingOperationNone,
+		}, res.operations)
+	})
+
+	t.Run("reports Updated when adopting an object that already exists without the owner reference", func(t *testing.T) {
+		rec, c := newEnv(t)
+		preexisting := buildConfigMap(map[string]string{"foo": "bar"})()
+		require.NoError(t, c.Create(t.Context(), preexisting))
+
+		res := &operationRecordingResource{build: buildConfigMap(map[string]string{"foo": "bar"})}
+		apply(t, rec, res)
+		apply(t, rec, res)
+
+		assert.Equal(t, []concepts.ConvergingOperation{
+			concepts.ConvergingOperationUpdated,
+			concepts.ConvergingOperationNone,
+		}, res.operations)
+	})
+
+	t.Run("classifies unstructured objects the same way", func(t *testing.T) {
+		rec, _ := newEnv(t)
+		data := map[string]any{"foo": "bar"}
+		build := func() client.Object {
+			u := &unstructured.Unstructured{}
+			u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+			u.SetName("rebuilt-unstructured")
+			u.SetNamespace(namespace)
+			require.NoError(t, unstructured.SetNestedField(u.Object, runtime.DeepCopyJSON(data), "data"))
+			return u
+		}
+		res := &unstructuredOperationRecordingResource{build: build}
+
+		apply(t, rec, res)
+		apply(t, rec, res)
+		data["foo"] = "baz"
+		apply(t, rec, res)
+		apply(t, rec, res)
+
+		assert.Equal(t, []concepts.ConvergingOperation{
+			concepts.ConvergingOperationCreated,
+			concepts.ConvergingOperationNone,
+			concepts.ConvergingOperationUpdated,
+			concepts.ConvergingOperationNone,
+		}, res.operations)
+	})
+
+	t.Run("reports None when a persistent desired object is re-applied unchanged", func(t *testing.T) {
+		rec, _ := newEnv(t)
+		// Same pointer on every reconcile: the SSA response is decoded back into it,
+		// which is how BaseResource.DesiredObject behaves across reconciles.
+		persistent := buildConfigMap(map[string]string{"foo": "bar"})()
+		res := &operationRecordingResource{build: func() *corev1.ConfigMap { return persistent }}
+
+		apply(t, rec, res)
+		apply(t, rec, res)
+
+		assert.Equal(t, []concepts.ConvergingOperation{
+			concepts.ConvergingOperationCreated,
+			concepts.ConvergingOperationNone,
+		}, res.operations)
 	})
 }
 

--- a/pkg/component/zz_mock_crd_test.go
+++ b/pkg/component/zz_mock_crd_test.go
@@ -14,7 +14,14 @@ type MockOperatorCRD struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	Spec   MockSpec   `json:"spec,omitempty"`
 	Status MockStatus `json:"status,omitempty"`
+}
+
+// MockSpec is a minimal spec so tests can apply a typed, JSON-decoded object
+// (CRDs are not served as protobuf) with a mutable desired field.
+type MockSpec struct {
+	Value string `json:"value,omitempty"`
 }
 
 type MockOperatorCRDList struct {

--- a/plugin/skills/building-components/references/component.md
+++ b/plugin/skills/building-components/references/component.md
@@ -330,6 +330,14 @@ do this automatically. Managed resources are applied with Server-Side Apply and 
 except where the owner is namespace-scoped and the resource is cluster-scoped (see
 [Cluster-scoped resources](#cluster-scoped-resources)).
 
+Each apply is classified as `Created`, `Updated` or `None` by comparing the object observed before the patch (read
+through the client, usually the informer cache) with the API server's response to it, ignoring `status`,
+`managedFields`, `resourceVersion` and `generation`. The classification is passed to the resource's status handler as
+its `concepts.ConvergingOperation` and drives the `Created<Kind>` and `Updated<Kind>` events recorded on the owner;
+`None` records no event. Because it compares observed cluster state rather than the desired object before and after
+mutation, a steady-state reconcile reports `None` regardless of whether the operator rebuilds its components on every
+reconcile or keeps them across reconciles.
+
 ### Previewing desired state
 
 `Component.Preview() ([]client.Object, error)` renders the desired state of every managed resource in registration order

--- a/plugin/skills/custom-resource-wrappers/references/custom-resource.md
+++ b/plugin/skills/custom-resource-wrappers/references/custom-resource.md
@@ -357,6 +357,16 @@ decodes the API server's response into that same object, so those handlers read 
 and `Status` included, and can trust `status.observedGeneration` to tell them whether the object's own controller has
 seen the spec just applied.
 
+The converge and operational status handlers also receive a `concepts.ConvergingOperation` that says what the apply did:
+`Created` when the object did not exist before, `Updated` when the apply changed an existing object, and `None` when it
+left the object as it was. The framework decides this by comparing the object observed before the Server-Side Apply
+(read through the client, usually the informer cache) with the API server's response, ignoring `status`,
+`managedFields`, `resourceVersion` and `generation`. It does not depend on how the desired object was built, so a
+wrapper reports `None` on a steady-state reconcile whether the operator keeps its resources across reconciles or
+rebuilds them each pass. Use the operation to distinguish `Creating` from `Updating` while `status.observedGeneration`
+lags, as the example below does; do not use it as a change detector for anything the apply cannot see, such as external
+state.
+
 Three handlers are outside that guarantee. The **guard** runs before the resource is applied, which is its whole
 purpose, so it sees the desired object rather than the server's response. The suspension **mutation** handler takes the
 mutator rather than the object and runs before the patch is sent. The **delete-on-suspend decision** may be consulted


### PR DESCRIPTION
## Description

Fixes #179

Operators that build their components on every reconcile saw every owned resource report `Updated` on every pass, with an `Updated<Kind>` event each time, because the converging operation was decided by comparing the desired object before and after `Mutate`, and the owner reference and feature mutations always change a freshly built object. In a real cluster this fills client-go's per-object event spam filter within seconds and drops the operator's own events. The apply is now classified by comparing the object observed before the Server-Side Apply (read through the client, usually the informer cache) with the API server's response to it, so `Updated` is reported only when the apply changed the object. A concurrent write by another actor between the cache read and the patch can still surface as one `Updated`; that is a real change to the observed object, not a perpetual one.

## Changes

- `applyResource` classifies each apply as `Created`/`Updated`/`None` from the object observed before vs. after the SSA patch, ignoring `status`, `managedFields`, `resourceVersion`, `generation` and TypeMeta; the pre-Mutate snapshot is gone.
- The existence check fetches into a zeroed object of the desired type instead of a deep copy of the desired object, so the pre-apply snapshot holds only what the client returned. A nil or non-pointer desired object now returns an error from `applyResource` instead of panicking.
- `ConvergingOperation` GoDoc and `docs/component.md` / `docs/custom-resource.md` now describe how the operation is derived and that it does not depend on how the desired object was built; `plugin/skills/*/references` re-synced from `docs/` (`make sync-plugin`).

## Testing

New fake-client tests in `create_test.go` cover a resource that rebuilds its object each apply (None on steady state, Updated on content change and when a mutation starts applying, Updated when adopting a pre-existing object), the unstructured path, the persistent-pointer builder, and `TestNewEmptyObjectLike` (typed, unstructured, nil interface, typed nil). New envtest cases in `component_test.go` reconcile a rebuilt ConfigMap and a rebuilt typed CRD object against a real API server and assert `Created, None, None, Updated, None` (ConfigMap, plus exactly one Created and one Updated event) and `Created, None, None, Updated` (CRD, with the status handler receiving exactly the server response); the ConfigMap case fails on `main` with `Created, Updated, Updated, Updated, Updated`. `make all` passes; `make e2e-component` (13/13) and `make e2e-primitives PRIMITIVE=deployment` (8/8) pass on kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
