### PR TITLE
fix(component): stop a re-enabled or resumed component reporting True/Blocked

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -455,6 +455,13 @@ stateDiagram-v2
     end note
 ```
 
+`Unknown`, `Disabled`, `FeatureGateError`, `PrerequisiteNotMet`, and the suspension reasons (`PendingSuspension`,
+`Suspending`, `Suspended`) are set outside the converge state machine. When a component enters convergence from one of
+them (its gate is re-enabled, its prerequisites are met, or it resumes from suspension), the condition is derived from
+scratch, exactly as from `Unknown`. The previous condition's status and `lastTransitionTime` are not carried forward: a
+component that was `True`/`Disabled` and blocks on a guard once re-enabled reports `False`/`Blocked`, and the grace
+period starts counting from the new transition rather than from the time the component was disabled or suspended.
+
 ### Reading a component's condition
 
 `(*Component).GetCondition(owner OperatorCRD) Condition` returns the condition this component owns on the given owner.

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -461,14 +461,25 @@ func (c *Component) Reconcile(ctx context.Context, rec ReconcileContext) error {
 	}
 
 	// Determine new condition for component
+	previous := c.GetCondition(rec.Owner)
 	cond := newConvergingStatusCondition(
 		ctx,
 		rec.Owner,
 		reconcileResults(results).filterParticipators(),
 		c.gracePeriod,
-		c.GetCondition(rec.Owner),
+		previous,
 	)
-	applyStatusCondition(rec, cond)
+	if Status(previous.Reason).converging() {
+		applyStatusCondition(rec, cond)
+	} else {
+		// Entering convergence from a condition produced outside the converge
+		// state machine: the grace period counts from this transition, so the
+		// transition time is stamped explicitly. meta.SetStatusCondition would
+		// keep the previous one whenever the status did not change (False to
+		// False), leaving the grace period already expired on the next reconcile.
+		cond.LastTransitionTime = metav1.Now()
+		replaceStatusCondition(rec.Owner.GetStatusConditions(), metav1.Condition(cond))
+	}
 
 	if err := deleteResources(ctx, rec, c.deleteResources); err != nil {
 		return fail(rec, c.conditionType, err)

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -164,6 +164,54 @@ var _ = Describe("Component Reconciler", func() {
 			Expect(cond.Reason).To(Equal(string(AliveCreating)))
 		})
 
+		It("should restart the grace period when entering convergence from a non-converging reason", func() {
+			// Given: the component sat behind a prerequisite barrier for an hour,
+			// so the owner carries an hour-old False/PrerequisiteNotMet condition.
+			// Because the status stays False when convergence starts, a plain
+			// meta.SetStatusCondition would keep that hour-old transition time
+			// and the 5-minute grace period would be expired on the very next
+			// reconcile.
+			owner.Status.Conditions = []metav1.Condition{{
+				Type:               "TestComponentReady",
+				Status:             metav1.ConditionFalse,
+				Reason:             string(PrerequisiteNotMet),
+				Message:            "waiting for backend",
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+			}}
+			comp.gracePeriod = 5 * time.Minute
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-reentry-cm", Namespace: namespace},
+			}
+			res := &MockAliveResource{}
+			res.On("Object").Return(cm, nil)
+			res.On("Identity").Return("ConfigMap/test-reentry-cm")
+			res.On("Mutate", mock.Anything).Return(nil)
+			res.On("ConvergingStatus", mock.Anything).Return(concepts.AliveStatusWithReason{
+				Status: concepts.AliveConvergingStatusCreating,
+				Reason: "Waiting for creation",
+			}, nil)
+			res.On("GraceStatus").Return(concepts.GraceStatusWithReason{
+				Status: concepts.GraceStatusDown,
+				Reason: "no replicas",
+			}, nil)
+			comp.reconcileResources = []reconcileEntry{{Resource: res, Options: resourceOptions{ParticipationMode: ParticipationModeRequired}}}
+
+			// When: the barrier passes and the component reconciles twice
+			Expect(comp.Reconcile(ctx, recCtx)).To(Succeed())
+			first := comp.GetCondition(owner)
+			Expect(comp.Reconcile(ctx, recCtx)).To(Succeed())
+
+			// Then: the transition time was reset on entry and the second reconcile
+			// is still inside the grace period
+			Expect(first.Reason).To(Equal(string(AliveCreating)))
+			Expect(first.LastTransitionTime.Time).To(BeTemporally("~", time.Now(), time.Minute))
+
+			cond := getOwnerCondition()
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(string(AliveCreating)))
+		})
+
 		It("should handle read-only resources", func() {
 			// Given
 			cm := &corev1.ConfigMap{

--- a/pkg/component/converge.go
+++ b/pkg/component/converge.go
@@ -166,8 +166,12 @@ func graceExpired(gracePeriod time.Duration, transition time.Time) bool {
 //
 //  1. Immediate Ready: If all resources are Ready, the component becomes Ready immediately.
 //
-//  2. Initialization: If no prior condition exists (Status=Unknown), it is initialized
-//     from the current aggregate status (Creating, Updating, etc.).
+//  2. Initialization: If no prior condition exists (Reason=Unknown), or the previous
+//     condition was produced outside this state machine (Disabled, FeatureGateError,
+//     PrerequisiteNotMet, or a suspension reason), it is initialized from the current
+//     aggregate status (Creating, Updating, etc.). The previous condition's Status and
+//     LastTransitionTime are not carried forward, so a component that was disabled
+//     or suspended does not inherit a True status or an expired grace period.
 //
 //  3. Recovery from Ready: If the previous status was Ready but resources are now unready,
 //     the status transitions to the current aggregate status.
@@ -204,14 +208,17 @@ func newConvergingStatusCondition(
 		return conditionReady(conditionType, generation)
 	}
 
-	// No condition is set, we create the initial condition from the converge summary
-	if previousCondition.Reason == string(Unknown) {
+	// Convert the previous condition reason to a component status
+	status := Status(previousCondition.Reason)
+
+	// The previous condition was not produced by this state machine (no condition
+	// yet, feature gate disabled, prerequisite barrier, suspension): its status and
+	// transition time say nothing about convergence, so derive the initial
+	// condition from the converge summary instead of building on it.
+	if !status.converging() {
 		summary := results.convergeSummary()
 		return convergingCondition(conditionType, summary, generation)
 	}
-
-	// Convert the previous condition reason to a component status
-	status := Status(previousCondition.Reason)
 
 	// Get the summary for an updated description of why we're here
 	convergeSummary := results.convergeSummary()

--- a/pkg/component/converge_test.go
+++ b/pkg/component/converge_test.go
@@ -654,3 +654,76 @@ func TestNewConvergingStatusCondition_Transitions(t *testing.T) {
 		assert.Equal(t, string(Healthy), cond.Reason)
 	})
 }
+
+// A condition whose reason was produced outside the converge state machine
+// (feature gate, prerequisite barrier, suspension) carries a status that says
+// nothing about convergence. Re-entering convergence from such a condition must
+// derive the new condition from scratch, exactly as from Unknown, rather than
+// copying the previous status forward.
+func TestNewConvergingStatusCondition_ReenteringConvergence(t *testing.T) {
+	var (
+		owner = &MockOperatorCRD{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-owner", Namespace: "test-ns", Generation: 1},
+		}
+		ctx = t.Context()
+	)
+
+	previousReasons := []struct {
+		reason Status
+		status metav1.ConditionStatus
+	}{
+		{Disabled, metav1.ConditionTrue},
+		{Suspended, metav1.ConditionTrue},
+		{Suspending, metav1.ConditionFalse},
+		{PendingSuspension, metav1.ConditionFalse},
+		{PrerequisiteNotMet, metav1.ConditionFalse},
+		{FeatureGateError, metav1.ConditionFalse},
+	}
+
+	for _, prev := range previousReasons {
+		previous := Condition{
+			Type:               "Test",
+			Status:             prev.status,
+			Reason:             string(prev.reason),
+			Message:            "stale message",
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+		}
+
+		t.Run("should report False/Blocked when re-entering from "+string(prev.reason), func(t *testing.T) {
+			results := reconcileResults{
+				{Status: convergingStatusWithReason{Status: convergingStatusGuardBlocked, Reason: "Waiting for base backup"}},
+			}
+
+			cond := newConvergingStatusCondition(ctx, owner, results, 5*time.Minute, previous)
+
+			assert.Equal(t, metav1.ConditionFalse, cond.Status)
+			assert.Equal(t, string(GuardBlocked), cond.Reason)
+			assert.Equal(t, "Waiting for base backup", cond.Message)
+		})
+
+		t.Run("should report False/Creating when re-entering from "+string(prev.reason), func(t *testing.T) {
+			results := reconcileResults{
+				{Status: convergingStatusWithReason{Status: convergingStatusAliveCreating, Reason: "Creating pods"}},
+			}
+
+			cond := newConvergingStatusCondition(ctx, owner, results, 5*time.Minute, previous)
+
+			assert.Equal(t, metav1.ConditionFalse, cond.Status)
+			assert.Equal(t, string(AliveCreating), cond.Reason)
+			assert.Equal(t, "Creating pods", cond.Message)
+		})
+
+		t.Run("should not evaluate grace against the stale transition time when re-entering from "+string(prev.reason), func(t *testing.T) {
+			results := reconcileResults{
+				{
+					Status:      convergingStatusWithReason{Status: convergingStatusAliveCreating, Reason: "Creating pods"},
+					GraceStatus: &concepts.GraceStatusWithReason{Status: concepts.GraceStatusDown, Reason: "no pods"},
+				},
+			}
+
+			cond := newConvergingStatusCondition(ctx, owner, results, 5*time.Minute, previous)
+
+			assert.Equal(t, string(AliveCreating), cond.Reason)
+		})
+	}
+}

--- a/pkg/component/status.go
+++ b/pkg/component/status.go
@@ -269,6 +269,20 @@ func (s Status) Healthy() bool {
 	return convergingStatus(s).healthy()
 }
 
+// converging reports whether the status was produced by the converge state
+// machine. Statuses set outside of it (the initial Unknown, the feature gate,
+// the prerequisite barrier, and suspension) carry a condition status that says
+// nothing about convergence, so a component entering convergence from one of
+// them must derive its condition from scratch rather than build on it.
+func (s Status) converging() bool {
+	switch s {
+	case Unknown, Disabled, FeatureGateError, PrerequisiteNotMet, PendingSuspension, Suspending, Suspended:
+		return false
+	default:
+		return true
+	}
+}
+
 func (s Status) sticky() bool {
 	switch s {
 	case AliveCreating, AliveUpdating, AliveScaling:

--- a/plugin/skills/building-components/references/component.md
+++ b/plugin/skills/building-components/references/component.md
@@ -455,6 +455,13 @@ stateDiagram-v2
     end note
 ```
 
+`Unknown`, `Disabled`, `FeatureGateError`, `PrerequisiteNotMet`, and the suspension reasons (`PendingSuspension`,
+`Suspending`, `Suspended`) are set outside the converge state machine. When a component enters convergence from one of
+them (its gate is re-enabled, its prerequisites are met, or it resumes from suspension), the condition is derived from
+scratch, exactly as from `Unknown`. The previous condition's status and `lastTransitionTime` are not carried forward: a
+component that was `True`/`Disabled` and blocks on a guard once re-enabled reports `False`/`Blocked`, and the grace
+period starts counting from the new transition rather than from the time the component was disabled or suspended.
+
 ### Reading a component's condition
 
 `(*Component).GetCondition(owner OperatorCRD) Condition` returns the condition this component owns on the given owner.


### PR DESCRIPTION
## Description

Fixes #194

A component whose feature gate was turned off and back on, or that resumed from suspension, reported a `True` condition with a non-ready reason such as `Blocked` or `Creating`, and kept doing so on every reconcile. `newConvergingStatusCondition` copied the previous `True`/`Disabled` (or `True`/`Suspended`) condition wholesale and only replaced the reason. This PR treats every reason produced outside the converge state machine (`Unknown`, `Disabled`, `FeatureGateError`, `PrerequisiteNotMet`, and the suspension reasons) as a fresh start and derives the condition from the converge summary, as was already done for `Unknown`. Because the disabled or suspended condition's `lastTransitionTime` is no longer reused, the grace period also starts counting from the re-entry instead of expiring on the first reconcile.

## Changes

- `Status.converging()` classifies which reasons the converge state machine owns; `newConvergingStatusCondition` re-initializes from the summary for every other reason, not just `Unknown`.
- When the previous reason is non-converging, `Reconcile` stamps a fresh `lastTransitionTime` and writes the condition verbatim instead of through `meta.SetStatusCondition`, which would keep the old time on a `False`→`False` re-entry and leave the grace period already expired on the next reconcile.
- `docs/component.md` (and the synced plugin reference) document re-entry into convergence from `Disabled`, `PrerequisiteNotMet`, and suspension.

## Testing

New table-driven unit tests in `pkg/component/converge_test.go` cover re-entry from each non-converging reason into `Blocked` and `Creating`, asserting `Status: False` and the summary's reason and message, plus a case with an hour-old `lastTransitionTime` and a `Down` grace status asserting the component is not declared `Down` on re-entry. All new cases failed before the fix (`True`/`Down` with the stale transition time, `True`/`Blocked` without it) and pass after. `make all` (lint, format, unit and envtest suites, example builds) is green. The existing `e2e/component/prerequisite_gate_test.go` re-enable case is unaffected: its ConfigMap converges to `Healthy` immediately and never passes through an intermediate state, so I did not run the E2E suite. A reconcile-level Ginkgo test reconciles twice from an hour-old `False`/`PrerequisiteNotMet` with a 5-minute grace period and asserts the transition time is reset and the component stays `Creating` rather than going `Down`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xiyM1zh7YpWQqQq5PohD1
